### PR TITLE
Define result variable

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -98,7 +98,7 @@ GradientParser.parse = (function() {
         error('Missing (');
       }
 
-      result = callback(captures);
+      var result = callback(captures);
 
       if (!scan(tokens.endCall)) {
         error('Missing )');


### PR DESCRIPTION
Some environments can throws error than variable is not defined.