### PR TITLE
Fix issue "undefined variable result" in built scripts as well

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -264,7 +264,7 @@ GradientParser.parse = (function() {
         error('Missing (');
       }
 
-      result = callback(captures);
+      var result = callback(captures);
 
       if (!scan(tokens.endCall)) {
         error('Missing )');

--- a/build/web.js
+++ b/build/web.js
@@ -100,7 +100,7 @@ GradientParser.parse = (function() {
         error('Missing (');
       }
 
-      result = callback(captures);
+      var result = callback(captures);
 
       if (!scan(tokens.endCall)) {
         error('Missing )');


### PR DESCRIPTION
This was fixed in https://github.com/rafaelcaricio/gradient-parser/pull/11, but the built scripts (`build/*`) were not updated accordingly. I basically cloned and ran 'grunt' on the repository to fix.