### PR TITLE
Support CSS variables (custom properties) in colors

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -98,6 +98,10 @@ GradientParser.stringify = (function() {
       return visitor.visit_color('#' + node.value, node);
     },
 
+    'visit_var': function(node) {
+      return visitor.visit_color('var(' + node.value + ')', node);
+    },
+
     'visit_rgb': function(node) {
       return visitor.visit_color('rgb(' + node.value.join(', ') + ')', node);
     },
@@ -192,6 +196,8 @@ GradientParser.parse = (function() {
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
+    varColor: /^var/i,
+    variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/
   };
 
@@ -427,6 +433,7 @@ GradientParser.parse = (function() {
     return matchHexColor() ||
       matchRGBAColor() ||
       matchRGBColor() ||
+      matchVarColor() ||
       matchLiteralColor();
   }
 
@@ -454,6 +461,19 @@ GradientParser.parse = (function() {
         value: matchListing(matchNumber)
       };
     });
+  }
+
+  function matchVarColor() {
+    return matchCall(tokens.varColor, function () {
+      return {
+        type: 'var',
+        value: matchVariableName()
+      };
+    });
+  }
+
+  function matchVariableName() {
+    return scan(tokens.variableName)[1];
   }
 
   function matchNumber() {

--- a/build/web.js
+++ b/build/web.js
@@ -27,6 +27,8 @@ GradientParser.parse = (function() {
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
+    varColor: /^var/i,
+    variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/
   };
 
@@ -262,6 +264,7 @@ GradientParser.parse = (function() {
     return matchHexColor() ||
       matchRGBAColor() ||
       matchRGBColor() ||
+      matchVarColor() ||
       matchLiteralColor();
   }
 
@@ -289,6 +292,19 @@ GradientParser.parse = (function() {
         value: matchListing(matchNumber)
       };
     });
+  }
+
+  function matchVarColor() {
+    return matchCall(tokens.varColor, function () {
+      return {
+        type: 'var',
+        value: matchVariableName()
+      };
+    });
+  }
+
+  function matchVariableName() {
+    return scan(tokens.variableName)[1];
   }
 
   function matchNumber() {
@@ -445,6 +461,10 @@ GradientParser.stringify = (function() {
 
     'visit_hex': function(node) {
       return visitor.visit_color('#' + node.value, node);
+    },
+
+    'visit_var': function(node) {
+      return visitor.visit_color('var(' + node.value + ')', node);
     },
 
     'visit_rgb': function(node) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,6 +25,8 @@ GradientParser.parse = (function() {
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
+    varColor: /^var/i,
+    variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/
   };
 
@@ -260,6 +262,7 @@ GradientParser.parse = (function() {
     return matchHexColor() ||
       matchRGBAColor() ||
       matchRGBColor() ||
+      matchVarColor() ||
       matchLiteralColor();
   }
 
@@ -287,6 +290,19 @@ GradientParser.parse = (function() {
         value: matchListing(matchNumber)
       };
     });
+  }
+
+  function matchVarColor() {
+    return matchCall(tokens.varColor, function () {
+      return {
+        type: 'var',
+        value: matchVariableName()
+      };
+    });
+  }
+
+  function matchVariableName() {
+    return scan(tokens.variableName)[1];
   }
 
   function matchNumber() {

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -106,6 +106,10 @@ GradientParser.stringify = (function() {
       return visitor.visit_color('rgba(' + node.value.join(', ') + ')', node);
     },
 
+    'visit_var': function(node) {
+      return visitor.visit_color('var(' + node.value + ')', node);
+    },
+
     'visit_color': function(resultColor, node) {
       var result = resultColor,
           length = visitor.visit(node.length);

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -159,7 +159,8 @@ describe('lib/parser.js', function () {
       {type: 'literal', unparsedValue: 'red', value: 'red'},
       {type: 'hex', unparsedValue: '#c2c2c2', value: 'c2c2c2'},
       {type: 'rgb', unparsedValue: 'rgb(243, 226, 195)', value: ['243', '226', '195']},
-      {type: 'rgba', unparsedValue: 'rgba(243, 226, 195)', value: ['243', '226', '195']}
+      {type: 'rgba', unparsedValue: 'rgba(243, 226, 195)', value: ['243', '226', '195']},
+      {type: 'var', unparsedValue: 'var(--color-red)', value: '--color-red'},
     ].forEach(function(color) {
       describe('parse color type '+ color.type, function() {
         beforeEach(function() {

--- a/spec/stringify.spec.js
+++ b/spec/stringify.spec.js
@@ -30,6 +30,11 @@ describe('lib/stringify.js', function () {
       expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
     });
 
+    it('should serialize gradient with var', function() {
+      var gradientDef = 'linear-gradient(var(--color-black), white)';
+      expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+    });
+
     it('should serialize gradient with rgb', function() {
       var gradientDef = 'linear-gradient(rgb(1, 2, 3), white)';
       expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);


### PR DESCRIPTION
Aloha, we noticed that the gradient parser doesn't yet support using CSS variables for colors. This PR adds that support so the parser does not reject gradients that use CSS variables.

Example: `linear-gradient(var(--color-black), white)` 

Note: this does not yet support nested CSS variables, e.g., `var(—color-black, var(--default-value))`.