### PR TITLE
Add support for radians in angle values

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -189,6 +189,7 @@ GradientParser.parse = (function() {
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
+    radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
@@ -291,7 +292,8 @@ GradientParser.parse = (function() {
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1);
+    return match('angular', tokens.angleValue, 1) ||
+      match('angular', tokens.radianValue, 1);
   }
 
   function matchListRadialOrientations() {

--- a/build/web.js
+++ b/build/web.js
@@ -20,6 +20,7 @@ GradientParser.parse = (function() {
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
+    radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
@@ -122,7 +123,8 @@ GradientParser.parse = (function() {
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1);
+    return match('angular', tokens.angleValue, 1) ||
+      match('angular', tokens.radianValue, 1);
   }
 
   function matchListRadialOrientations() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,6 +18,7 @@ GradientParser.parse = (function() {
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
+    radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
@@ -120,7 +121,8 @@ GradientParser.parse = (function() {
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1);
+    return match('angular', tokens.angleValue, 1) ||
+      match('angular', tokens.radianValue, 1);
   }
 
   function matchListRadialOrientations() {

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -134,6 +134,7 @@ describe('lib/parser.js', function () {
   describe('parse all linear directional', function() {
     [
       {type: 'angular', unparsedValue: '-145deg', value: '-145'},
+      {type: 'angular', unparsedValue: '1rad', value: '1'},
       {type: 'directional', unparsedValue: 'to left top', value: 'left top'},
       {type: 'directional', unparsedValue: 'to top left', value: 'top left'},
       {type: 'directional', unparsedValue: 'to top right', value: 'top right'},


### PR DESCRIPTION
# Add support for radians in angle values

## Problem

Fixes #24

When using radians (rad) as the angle unit in a linear gradient, the parser throws an error:
`Error: 1rad, red, green): Expected color definition`

This happens because the parser only supports angles specified in degrees (deg) and doesn't recognize the radians unit.
 

## Solution
- Added support for radians (rad) unit in angle values by creating a new token pattern
- Updated the matchAngle function to check for both degrees and radians
- Added a test case to verify radians support works correctly

## Testing
- Added a specific test case for radians in the "parse all linear directional" section
- All tests pass, confirming the implementation is working correctly
- Manually tested with `linear-gradient(1rad, red, green)`

This change makes the gradient parser more complete and compliant with CSS standards, which allow angles to be specified in multiple units including radians.