### PR TITLE
Fix parser to handle gradient strings with trailing semicolons

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -358,7 +358,11 @@ GradientParser.parse = (function() {
   }
 
   return function(code) {
-    input = code.toString();
+    input = code.toString().trim();
+    // Remove trailing semicolon if present
+    if (input.endsWith(';')) {
+      input = input.slice(0, -1);
+    }
     return getAST();
   };
 })();

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -216,4 +216,39 @@ describe('lib/parser.js', function () {
     });
   });
 
+  describe('parse gradient strings with trailing semicolons', function() {
+    it('should parse linear-gradient with trailing semicolon', function() {
+      const inputWithSemicolon = 'linear-gradient(red, blue);';
+      const ast = gradients.parse(inputWithSemicolon);
+      expect(ast[0].type).to.equal('linear-gradient');
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].value).to.equal('red');
+      expect(ast[0].colorStops[1].value).to.equal('blue');
+    });
+
+    it('should parse radial-gradient with trailing semicolon', function() {
+      const inputWithSemicolon = 'radial-gradient(circle, red, blue);';
+      const ast = gradients.parse(inputWithSemicolon);
+      expect(ast[0].type).to.equal('radial-gradient');
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].value).to.equal('red');
+      expect(ast[0].colorStops[1].value).to.equal('blue');
+    });
+
+    it('should parse complex gradient with trailing semicolon', function() {
+      const inputWithSemicolon = 'linear-gradient(to right, rgb(22, 234, 174) 0%, rgb(126, 32, 207) 100%);';
+      const ast = gradients.parse(inputWithSemicolon);
+      expect(ast[0].type).to.equal('linear-gradient');
+      expect(ast[0].orientation.type).to.equal('directional');
+      expect(ast[0].orientation.value).to.equal('right');
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].length.type).to.equal('%');
+      expect(ast[0].colorStops[0].length.value).to.equal('0');
+      expect(ast[0].colorStops[1].type).to.equal('rgb');
+      expect(ast[0].colorStops[1].length.type).to.equal('%');
+      expect(ast[0].colorStops[1].length.value).to.equal('100');
+    });
+  });
+
 });


### PR DESCRIPTION
## Problem

Fixes #22 

When users copy gradient strings from CSS files or use values from `style` attributes, these strings often include a trailing semicolon (e.g., `linear-gradient(red, blue);`). The current parser implementation throws an error when trying to parse such strings:

```
Uncaught Error: [string with semicolon]: Invalid input not EOF
```

## Solution
- Updated the parser to trim the input string and remove any trailing semicolon
- Added unit tests to verify that gradient strings with trailing semicolons are properly parsed

## Test Cases
- Simple linear gradients: `linear-gradient(red, blue);`
- Radial gradients: `radial-gradient(circle, red, blue);`
- Complex gradients with RGB values and percentages: `linear-gradient(to right, rgb(22, 234, 174) 0%, rgb(126, 32, 207) 100%);`
