### PR TITLE
Fix parsing of radial gradients with ellipse dimensions followed by position

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -190,7 +190,7 @@ GradientParser.parse = (function() {
     var ellipse = match('shape', /^(ellipse)/i, 0);
 
     if (ellipse) {
-      ellipse.style =  matchDistance() || matchExtentKeyword();
+      ellipse.style = matchPositioning() || matchDistance() || matchExtentKeyword();
     }
 
     return ellipse;

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -142,6 +142,13 @@ GradientParser.stringify = (function() {
       return result;
     },
 
+    'visit_object': function(obj) {
+      if (obj.width && obj.height) {
+        return visitor.visit(obj.width) + ' ' + visitor.visit(obj.height);
+      }
+      return '';
+    },
+
     'visit': function(element) {
       if (!element) {
         return '';
@@ -150,6 +157,8 @@ GradientParser.stringify = (function() {
 
       if (element instanceof Array) {
         return visitor.visit_array(element, result);
+      } else if (typeof element === 'object' && !element.type) {
+        return visitor.visit_object(element);
       } else if (element.type) {
         var nodeVisitor = visitor['visit_' + element.type];
         if (nodeVisitor) {

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -214,6 +214,66 @@ describe('lib/parser.js', function () {
       });
 
     });
+    
+    it('should parse ellipse with dimensions and position', function() {
+      const gradient = 'repeating-radial-gradient(ellipse 40px 134px at 50% 96%, rgb(0, 165, 223) 0%, rgb(62, 20, 123) 6.6%)';
+      const ast = gradients.parse(gradient);
+      
+      expect(ast[0].type).to.equal('repeating-radial-gradient');
+      expect(ast[0].orientation[0].type).to.equal('shape');
+      expect(ast[0].orientation[0].value).to.equal('ellipse');
+      
+      // Check the style (size dimensions)
+      expect(ast[0].orientation[0].style.type).to.equal('position');
+      expect(ast[0].orientation[0].style.value.x.type).to.equal('px');
+      expect(ast[0].orientation[0].style.value.x.value).to.equal('40');
+      expect(ast[0].orientation[0].style.value.y.type).to.equal('px');
+      expect(ast[0].orientation[0].style.value.y.value).to.equal('134');
+      
+      // Check the position
+      expect(ast[0].orientation[0].at.type).to.equal('position');
+      expect(ast[0].orientation[0].at.value.x.type).to.equal('%');
+      expect(ast[0].orientation[0].at.value.x.value).to.equal('50');
+      expect(ast[0].orientation[0].at.value.y.type).to.equal('%');
+      expect(ast[0].orientation[0].at.value.y.value).to.equal('96');
+      
+      // Check the color stops
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].value).to.eql(['0', '165', '223']);
+      expect(ast[0].colorStops[0].length.type).to.equal('%');
+      expect(ast[0].colorStops[0].length.value).to.equal('0');
+      
+      expect(ast[0].colorStops[1].type).to.equal('rgb');
+      expect(ast[0].colorStops[1].value).to.eql(['62', '20', '123']);
+      expect(ast[0].colorStops[1].length.type).to.equal('%');
+      expect(ast[0].colorStops[1].length.value).to.equal('6.6');
+    });
+    
+    it('should parse full Pride flag gradient', function() {
+      const gradient = 'repeating-radial-gradient(ellipse 40px 134px at 50% 96%,rgb(0, 165, 223) 0%,rgb(62, 20, 123) 6.6%,rgb(226, 0, 121) 13.2%,rgb(223, 19, 44) 18.8%,rgb(243, 239, 21) 24.1%,rgb(0, 152, 71) 33.3%)';
+      const ast = gradients.parse(gradient);
+      
+      expect(ast[0].type).to.equal('repeating-radial-gradient');
+      expect(ast[0].orientation[0].type).to.equal('shape');
+      expect(ast[0].orientation[0].value).to.equal('ellipse');
+      
+      // Check dimensions and position
+      expect(ast[0].orientation[0].style.type).to.equal('position');
+      expect(ast[0].orientation[0].at.type).to.equal('position');
+      
+      // Verify all color stops are present (Pride flag colors)
+      expect(ast[0].colorStops).to.have.length(6);
+      
+      // Check the first and last color stops
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].value).to.eql(['0', '165', '223']);
+      
+      expect(ast[0].colorStops[5].type).to.equal('rgb');
+      expect(ast[0].colorStops[5].value).to.eql(['0', '152', '71']);
+      expect(ast[0].colorStops[5].length.type).to.equal('%');
+      expect(ast[0].colorStops[5].length.value).to.equal('33.3');
+    });
   });
 
   describe('parse gradient strings with trailing semicolons', function() {


### PR DESCRIPTION
## Problem
Fixes #1 
The gradient parser was unable to correctly parse repeating-radial-gradient patterns with ellipse dimensions followed by position, such as:
`repeating-radial-gradient(ellipse 40px 134px at 50% 96%, rgb(0, 165, 223) 0%, ...)`

This resulted in the error:
`Uncaught Error: 134px at 50% 96%,rgb(0, 165, 223) 0%,rgb(62, 20, 123) 6.6%...: Missing comma before color stops`

## Solution
Modified the `matchEllipse()` function to properly handle ellipse with dimensions followed by position by adding support for positioning in the ellipse style:

```javascript
ellipse.style = matchPositioning() || matchDistance() || matchExtentKeyword();
```

Added comprehensive tests to verify the fix works for various gradient patterns including Pride flag colors.