### PR TITLE
Add HSL/HSLA color support

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -106,6 +106,16 @@ GradientParser.stringify = (function() {
       return visitor.visit_color('rgba(' + node.value.join(', ') + ')', node);
     },
 
+    'visit_hsl': function(node) {
+      const [h, s, l] = node.value;
+      return visitor.visit_color(`hsl(${h}, ${s}%, ${l}%)`, node);
+    },
+
+    'visit_hsla': function(node) {
+      const [h, s, l, a] = node.value;
+      return visitor.visit_color(`hsla(${h}, ${s}%, ${l}%, ${a})`, node);
+    },
+
     'visit_var': function(node) {
       return visitor.visit_color('var(' + node.value + ')', node);
     },
@@ -208,7 +218,9 @@ GradientParser.parse = (function() {
     rgbaColor: /^rgba/i,
     varColor: /^var/i,
     variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
-    number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/
+    number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
+    hslColor: /^hsl/i,
+    hslaColor: /^hsla/i,
   };
 
   var input = '';
@@ -442,6 +454,8 @@ GradientParser.parse = (function() {
 
   function matchColor() {
     return matchHexColor() ||
+      matchHSLAColor() ||
+      matchHSLColor() ||
       matchRGBAColor() ||
       matchRGBColor() ||
       matchVarColor() ||
@@ -481,6 +495,41 @@ GradientParser.parse = (function() {
         value: matchVariableName()
       };
     });
+  }
+
+  function matchHSLColor() {
+    return matchCall(tokens.hslColor, function() {
+      var hue = matchNumber();
+      scan(tokens.comma);
+      var sat = matchPercentage();
+      scan(tokens.comma);
+      var light = matchPercentage();
+      return {
+        type: 'hsl',
+        value: [hue, sat, light]
+      };
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      var hue = matchNumber();
+      scan(tokens.comma);
+      var sat = matchPercentage();
+      scan(tokens.comma);
+      var light = matchPercentage();
+      scan(tokens.comma);
+      var alpha = matchNumber();
+      return {
+        type: 'hsla',
+        value: [hue, sat, light, alpha]
+      };
+    });
+  }
+
+  function matchPercentage() {
+    var captures = scan(tokens.percentageValue);
+    return captures ? captures[1] : null;
   }
 
   function matchVariableName() {

--- a/build/web.js
+++ b/build/web.js
@@ -311,11 +311,22 @@ GradientParser.parse = (function() {
 
   function matchHSLColor() {
     return matchCall(tokens.hslColor, function() {
+      // Check for percentage before trying to parse the hue
+      var lookahead = scan(tokens.percentageValue);
+      if (lookahead) {
+        error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+      }
+      
       var hue = matchNumber();
       scan(tokens.comma);
-      var sat = matchPercentage();
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
       scan(tokens.comma);
-      var light = matchPercentage();
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSL');
+      }
       return {
         type: 'hsl',
         value: [hue, sat, light]
@@ -327,11 +338,16 @@ GradientParser.parse = (function() {
     return matchCall(tokens.hslaColor, function() {
       var hue = matchNumber();
       scan(tokens.comma);
-      var sat = matchPercentage();
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
       scan(tokens.comma);
-      var light = matchPercentage();
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
       scan(tokens.comma);
       var alpha = matchNumber();
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSLA');
+      }
       return {
         type: 'hsla',
         value: [hue, sat, light, alpha]
@@ -517,13 +533,11 @@ GradientParser.stringify = (function() {
     },
 
     'visit_hsl': function(node) {
-      const [h, s, l] = node.value;
-      return visitor.visit_color(`hsl(${h}, ${s}%, ${l}%)`, node);
+      return visitor.visit_color('hsl(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%)', node);
     },
 
     'visit_hsla': function(node) {
-      const [h, s, l, a] = node.value;
-      return visitor.visit_color(`hsla(${h}, ${s}%, ${l}%, ${a})`, node);
+      return visitor.visit_color('hsla(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%, ' + node.value[3] + ')', node);
     },
 
     'visit_var': function(node) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,9 @@ GradientParser.parse = (function() {
     rgbaColor: /^rgba/i,
     varColor: /^var/i,
     variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
-    number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/
+    number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
+    hslColor: /^hsl/i,
+    hslaColor: /^hsla/i,
   };
 
   var input = '';
@@ -262,6 +264,8 @@ GradientParser.parse = (function() {
 
   function matchColor() {
     return matchHexColor() ||
+      matchHSLAColor() ||
+      matchHSLColor() ||
       matchRGBAColor() ||
       matchRGBColor() ||
       matchVarColor() ||
@@ -301,6 +305,51 @@ GradientParser.parse = (function() {
         value: matchVariableName()
       };
     });
+  }
+
+  function matchHSLColor() {
+    return matchCall(tokens.hslColor, function() {
+      var hue = matchNumber();
+      scan(tokens.comma);
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
+      scan(tokens.comma);
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSL');
+      }
+      return {
+        type: 'hsl',
+        value: [hue, sat, light]
+      };
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      var hue = matchNumber();
+      scan(tokens.comma);
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
+      scan(tokens.comma);
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
+      scan(tokens.comma);
+      var alpha = matchNumber();
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSLA');
+      }
+      return {
+        type: 'hsla',
+        value: [hue, sat, light, alpha]
+      };
+    });
+  }
+
+  function matchPercentage() {
+    var captures = scan(tokens.percentageValue);
+    return captures ? captures[1] : null;
   }
 
   function matchVariableName() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -309,6 +309,12 @@ GradientParser.parse = (function() {
 
   function matchHSLColor() {
     return matchCall(tokens.hslColor, function() {
+      // Check for percentage before trying to parse the hue
+      var lookahead = scan(tokens.percentageValue);
+      if (lookahead) {
+        error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+      }
+      
       var hue = matchNumber();
       scan(tokens.comma);
       var captures = scan(tokens.percentageValue);

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -106,6 +106,14 @@ GradientParser.stringify = (function() {
       return visitor.visit_color('rgba(' + node.value.join(', ') + ')', node);
     },
 
+    'visit_hsl': function(node) {
+      return visitor.visit_color('hsl(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%)', node);
+    },
+
+    'visit_hsla': function(node) {
+      return visitor.visit_color('hsla(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%, ' + node.value[3] + ')', node);
+    },
+
     'visit_var': function(node) {
       return visitor.visit_color('var(' + node.value + ')', node);
     },

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -163,6 +163,7 @@ describe('lib/parser.js', function () {
       {type: 'rgba', unparsedValue: 'rgba(243, 226, 195)', value: ['243', '226', '195']},
       {type: 'hsl', unparsedValue: 'hsl(120, 60%, 70%)', value: ['120', '60', '70']},
       {type: 'hsla', unparsedValue: 'hsla(120, 60%, 70%, 0.3)', value: ['120', '60', '70', '0.3']},
+      {type: 'hsla', unparsedValue: 'hsla(240, 100%, 50%, 0.5)', value: ['240', '100', '50', '0.5']},
       {type: 'var', unparsedValue: 'var(--color-red)', value: '--color-red'},
     ].forEach(function(color) {
       describe('parse color type '+ color.type, function() {
@@ -194,7 +195,7 @@ describe('lib/parser.js', function () {
       it('should error on percentage for hue', function() {
         expect(function() {
           gradients.parse('linear-gradient(hsl(120%, 60%, 70%))');
-        }).to.throwException(/Expected color definition/);
+        }).to.throwException(/HSL hue value must be a number in degrees \(0-360\) or normalized \(-360 to 360\), not a percentage/);
       });
     });
   });
@@ -352,6 +353,28 @@ describe('lib/parser.js', function () {
       expect(ast[0].colorStops[1].value).to.eql(['172', '79', '115']);
       expect(ast[0].colorStops[1].length.type).to.equal('%');
       expect(ast[0].colorStops[1].length.value).to.equal('100');
+    });
+
+    describe('parse different color formats', function() {
+      const testGradients = [
+        'linear-gradient(red, blue)',
+        'linear-gradient(red, #00f)',
+        'linear-gradient(red, #0000ff)',
+        'linear-gradient(red, rgb(0, 0, 255))',
+        'linear-gradient(red, rgba(0, 0, 255, 1))',
+        'linear-gradient(red, hsl(240, 50%, 100%))',
+        'linear-gradient(red, hsla(240, 50%, 100%, 1))'
+      ];
+
+      testGradients.forEach(function(gradient) {
+        it('should parse ' + gradient, function() {
+          const result = gradients.parse(gradient);
+          expect(result[0].type).to.equal('linear-gradient');
+          expect(result[0].colorStops).to.have.length(2);
+          expect(result[0].colorStops[0].type).to.equal('literal');
+          expect(result[0].colorStops[0].value).to.equal('red');
+        });
+      });
     });
   });
 

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -161,6 +161,8 @@ describe('lib/parser.js', function () {
       {type: 'hex', unparsedValue: '#c2c2c2', value: 'c2c2c2'},
       {type: 'rgb', unparsedValue: 'rgb(243, 226, 195)', value: ['243', '226', '195']},
       {type: 'rgba', unparsedValue: 'rgba(243, 226, 195)', value: ['243', '226', '195']},
+      {type: 'hsl', unparsedValue: 'hsl(120, 60%, 70%)', value: ['120', '60', '70']},
+      {type: 'hsla', unparsedValue: 'hsla(120, 60%, 70%, 0.3)', value: ['120', '60', '70', '0.3']},
       {type: 'var', unparsedValue: 'var(--color-red)', value: '--color-red'},
     ].forEach(function(color) {
       describe('parse color type '+ color.type, function() {
@@ -173,6 +175,26 @@ describe('lib/parser.js', function () {
             expect(subject.type).to.equal(color.type);
             expect(subject.value).to.eql(color.value);
           });
+      });
+    });
+
+    describe('error cases for HSL/HSLA', function() {
+      it('should error on missing percentage for saturation', function() {
+        expect(function() {
+          gradients.parse('linear-gradient(hsl(120, 60, 70%))');
+        }).to.throwException(/Expected percentage value/);
+      });
+
+      it('should error on missing percentage for lightness', function() {
+        expect(function() {
+          gradients.parse('linear-gradient(hsl(120, 60%, 70))');
+        }).to.throwException(/Expected percentage value/);
+      });
+
+      it('should error on percentage for hue', function() {
+        expect(function() {
+          gradients.parse('linear-gradient(hsl(120%, 60%, 70%))');
+        }).to.throwException(/Expected color definition/);
       });
     });
   });


### PR DESCRIPTION
Fixes #3 

Adds support for parsing HSL and HSLA color values in gradients according to CSS Color Module Level 4 spec including:

- HSL color parsing with percentage validation for saturation and lightness
- HSLA color parsing with alpha channel support
- Test coverage for HSL/HSLA parsing and error cases
- Proper serialization of HSL/HSLA values