### PR TITLE
Add support for calc() expressions in gradient positions

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -90,6 +90,10 @@ GradientParser.stringify = (function() {
       return node.value + 'px';
     },
 
+    'visit_calc': function(node) {
+      return 'calc(' + node.value + ')';
+    },
+
     'visit_literal': function(node) {
       return visitor.visit_color(node.value, node);
     },
@@ -215,6 +219,7 @@ GradientParser.parse = (function() {
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
     varColor: /^var/i,
+    calcValue: /^calc/i,
     variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
     hslColor: /^hsl/i,
@@ -557,11 +562,47 @@ GradientParser.parse = (function() {
   function matchDistance() {
     return match('%', tokens.percentageValue, 1) ||
       matchPositionKeyword() ||
+      matchCalc() ||
       matchLength();
   }
 
   function matchPositionKeyword() {
     return match('position-keyword', tokens.positionKeywords, 1);
+  }
+
+  function matchCalc() {
+    return matchCall(tokens.calcValue, function() {
+      var openParenCount = 1; // Start with the opening parenthesis from calc(
+      var calcContentStart = input.length;
+      var i = 0;
+      
+      // Parse through the content looking for balanced parentheses
+      while (openParenCount > 0 && i < input.length) {
+        var char = input.charAt(i);
+        if (char === '(') {
+          openParenCount++;
+        } else if (char === ')') {
+          openParenCount--;
+        }
+        i++;
+      }
+      
+      // If we exited because we ran out of input but still have open parentheses, error
+      if (openParenCount > 0) {
+        error('Missing closing parenthesis in calc() expression');
+      }
+      
+      // Get the content inside the calc() without the last closing paren
+      var calcContent = input.substring(0, i - 1);
+      
+      // Consume the calc expression content
+      consume(i - 1); // -1 because we don't want to consume the closing parenthesis
+      
+      return {
+        type: 'calc',
+        value: calcContent
+      };
+    });
   }
 
   function matchLength() {

--- a/build/node.js
+++ b/build/node.js
@@ -573,7 +573,6 @@ GradientParser.parse = (function() {
   function matchCalc() {
     return matchCall(tokens.calcValue, function() {
       var openParenCount = 1; // Start with the opening parenthesis from calc(
-      var calcContentStart = input.length;
       var i = 0;
       
       // Parse through the content looking for balanced parentheses

--- a/build/web.js
+++ b/build/web.js
@@ -383,7 +383,6 @@ GradientParser.parse = (function() {
   function matchCalc() {
     return matchCall(tokens.calcValue, function() {
       var openParenCount = 1; // Start with the opening parenthesis from calc(
-      var calcContentStart = input.length;
       var i = 0;
       
       // Parse through the content looking for balanced parentheses

--- a/build/web.js
+++ b/build/web.js
@@ -29,6 +29,7 @@ GradientParser.parse = (function() {
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
     varColor: /^var/i,
+    calcValue: /^calc/i,
     variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
     hslColor: /^hsl/i,
@@ -371,11 +372,47 @@ GradientParser.parse = (function() {
   function matchDistance() {
     return match('%', tokens.percentageValue, 1) ||
       matchPositionKeyword() ||
+      matchCalc() ||
       matchLength();
   }
 
   function matchPositionKeyword() {
     return match('position-keyword', tokens.positionKeywords, 1);
+  }
+
+  function matchCalc() {
+    return matchCall(tokens.calcValue, function() {
+      var openParenCount = 1; // Start with the opening parenthesis from calc(
+      var calcContentStart = input.length;
+      var i = 0;
+      
+      // Parse through the content looking for balanced parentheses
+      while (openParenCount > 0 && i < input.length) {
+        var char = input.charAt(i);
+        if (char === '(') {
+          openParenCount++;
+        } else if (char === ')') {
+          openParenCount--;
+        }
+        i++;
+      }
+      
+      // If we exited because we ran out of input but still have open parentheses, error
+      if (openParenCount > 0) {
+        error('Missing closing parenthesis in calc() expression');
+      }
+      
+      // Get the content inside the calc() without the last closing paren
+      var calcContent = input.substring(0, i - 1);
+      
+      // Consume the calc expression content
+      consume(i - 1); // -1 because we don't want to consume the closing parenthesis
+      
+      return {
+        type: 'calc',
+        value: calcContent
+      };
+    });
   }
 
   function matchLength() {
@@ -514,6 +551,10 @@ GradientParser.stringify = (function() {
 
     'visit_px': function(node) {
       return node.value + 'px';
+    },
+
+    'visit_calc': function(node) {
+      return 'calc(' + node.value + ')';
     },
 
     'visit_literal': function(node) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -27,6 +27,7 @@ GradientParser.parse = (function() {
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
     varColor: /^var/i,
+    calcValue: /^calc/i,
     variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
     number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
     hslColor: /^hsl/i,
@@ -369,11 +370,47 @@ GradientParser.parse = (function() {
   function matchDistance() {
     return match('%', tokens.percentageValue, 1) ||
       matchPositionKeyword() ||
+      matchCalc() ||
       matchLength();
   }
 
   function matchPositionKeyword() {
     return match('position-keyword', tokens.positionKeywords, 1);
+  }
+
+  function matchCalc() {
+    return matchCall(tokens.calcValue, function() {
+      var openParenCount = 1; // Start with the opening parenthesis from calc(
+      var calcContentStart = input.length;
+      var i = 0;
+      
+      // Parse through the content looking for balanced parentheses
+      while (openParenCount > 0 && i < input.length) {
+        var char = input.charAt(i);
+        if (char === '(') {
+          openParenCount++;
+        } else if (char === ')') {
+          openParenCount--;
+        }
+        i++;
+      }
+      
+      // If we exited because we ran out of input but still have open parentheses, error
+      if (openParenCount > 0) {
+        error('Missing closing parenthesis in calc() expression');
+      }
+      
+      // Get the content inside the calc() without the last closing paren
+      var calcContent = input.substring(0, i - 1);
+      
+      // Consume the calc expression content
+      consume(i - 1); // -1 because we don't want to consume the closing parenthesis
+      
+      return {
+        type: 'calc',
+        value: calcContent
+      };
+    });
   }
 
   function matchLength() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -381,7 +381,6 @@ GradientParser.parse = (function() {
   function matchCalc() {
     return matchCall(tokens.calcValue, function() {
       var openParenCount = 1; // Start with the opening parenthesis from calc(
-      var calcContentStart = input.length;
       var i = 0;
       
       // Parse through the content looking for balanced parentheses

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -90,6 +90,10 @@ GradientParser.stringify = (function() {
       return node.value + 'px';
     },
 
+    'visit_calc': function(node) {
+      return 'calc(' + node.value + ')';
+    },
+
     'visit_literal': function(node) {
       return visitor.visit_color(node.value, node);
     },

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -376,6 +376,107 @@ describe('lib/parser.js', function () {
         });
       });
     });
+
+    describe('parse calc expressions', function() {
+      it('should parse linear gradient with calc in color stop position', function() {
+        const gradient = 'linear-gradient(to right, red calc(10% + 20px), blue 50%)';
+        const ast = gradients.parse(gradient);
+        
+        expect(ast[0].type).to.equal('linear-gradient');
+        expect(ast[0].orientation.type).to.equal('directional');
+        expect(ast[0].orientation.value).to.equal('right');
+        
+        expect(ast[0].colorStops).to.have.length(2);
+        expect(ast[0].colorStops[0].type).to.equal('literal');
+        expect(ast[0].colorStops[0].value).to.equal('red');
+        expect(ast[0].colorStops[0].length.type).to.equal('calc');
+        expect(ast[0].colorStops[0].length.value).to.equal('10% + 20px');
+        
+        expect(ast[0].colorStops[1].type).to.equal('literal');
+        expect(ast[0].colorStops[1].value).to.equal('blue');
+        expect(ast[0].colorStops[1].length.type).to.equal('%');
+        expect(ast[0].colorStops[1].length.value).to.equal('50');
+      });
+
+      it('should parse radial gradient with calc in position', function() {
+        const gradient = 'radial-gradient(circle at calc(50% + 25px) 50%, red, blue)';
+        const ast = gradients.parse(gradient);
+        
+        expect(ast[0].type).to.equal('radial-gradient');
+        expect(ast[0].orientation[0].type).to.equal('shape');
+        expect(ast[0].orientation[0].value).to.equal('circle');
+        
+        // Check the position
+        expect(ast[0].orientation[0].at.type).to.equal('position');
+        expect(ast[0].orientation[0].at.value.x.type).to.equal('calc');
+        expect(ast[0].orientation[0].at.value.x.value).to.equal('50% + 25px');
+        expect(ast[0].orientation[0].at.value.y.type).to.equal('%');
+        expect(ast[0].orientation[0].at.value.y.value).to.equal('50');
+        
+        // Check the color stops
+        expect(ast[0].colorStops).to.have.length(2);
+        expect(ast[0].colorStops[0].value).to.equal('red');
+        expect(ast[0].colorStops[1].value).to.equal('blue');
+      });
+
+      it('should parse calc expressions with multiple operations', function() {
+        const gradient = 'linear-gradient(90deg, yellow calc(100% - 50px), green calc(100% - 20px))';
+        const ast = gradients.parse(gradient);
+        
+        expect(ast[0].type).to.equal('linear-gradient');
+        expect(ast[0].orientation.type).to.equal('angular');
+        expect(ast[0].orientation.value).to.equal('90');
+        
+        expect(ast[0].colorStops).to.have.length(2);
+        expect(ast[0].colorStops[0].type).to.equal('literal');
+        expect(ast[0].colorStops[0].value).to.equal('yellow');
+        expect(ast[0].colorStops[0].length.type).to.equal('calc');
+        expect(ast[0].colorStops[0].length.value).to.equal('100% - 50px');
+        
+        expect(ast[0].colorStops[1].type).to.equal('literal');
+        expect(ast[0].colorStops[1].value).to.equal('green');
+        expect(ast[0].colorStops[1].length.type).to.equal('calc');
+        expect(ast[0].colorStops[1].length.value).to.equal('100% - 20px');
+      });
+      
+      it('should parse calc expressions with nested parentheses', function() {
+        const gradient = 'linear-gradient(to bottom, red calc(50% + (25px * 2)), blue)';
+        const ast = gradients.parse(gradient);
+        
+        expect(ast[0].type).to.equal('linear-gradient');
+        expect(ast[0].orientation.type).to.equal('directional');
+        expect(ast[0].orientation.value).to.equal('bottom');
+        
+        expect(ast[0].colorStops).to.have.length(2);
+        expect(ast[0].colorStops[0].type).to.equal('literal');
+        expect(ast[0].colorStops[0].value).to.equal('red');
+        expect(ast[0].colorStops[0].length.type).to.equal('calc');
+        expect(ast[0].colorStops[0].length.value).to.equal('50% + (25px * 2)');
+      });
+      
+      it('should parse multiple calc expressions in the same gradient', function() {
+        const gradient = 'radial-gradient(circle at calc(50% - 10px) calc(50% + 10px), red calc(20% + 10px), blue)';
+        const ast = gradients.parse(gradient);
+        
+        expect(ast[0].type).to.equal('radial-gradient');
+        expect(ast[0].orientation[0].type).to.equal('shape');
+        expect(ast[0].orientation[0].value).to.equal('circle');
+        
+        // Check the position
+        expect(ast[0].orientation[0].at.type).to.equal('position');
+        expect(ast[0].orientation[0].at.value.x.type).to.equal('calc');
+        expect(ast[0].orientation[0].at.value.x.value).to.equal('50% - 10px');
+        expect(ast[0].orientation[0].at.value.y.type).to.equal('calc');
+        expect(ast[0].orientation[0].at.value.y.value).to.equal('50% + 10px');
+        
+        // Check the color stops
+        expect(ast[0].colorStops).to.have.length(2);
+        expect(ast[0].colorStops[0].type).to.equal('literal');
+        expect(ast[0].colorStops[0].value).to.equal('red');
+        expect(ast[0].colorStops[0].length.type).to.equal('calc');
+        expect(ast[0].colorStops[0].length.value).to.equal('20% + 10px');
+      });
+    });
   });
 
 });

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -476,6 +476,21 @@ describe('lib/parser.js', function () {
         expect(ast[0].colorStops[0].length.type).to.equal('calc');
         expect(ast[0].colorStops[0].length.value).to.equal('20% + 10px');
       });
+
+      it('should throw an error for unbalanced parentheses in calc expressions', function() {
+        // Different test cases throw different errors, so we need to be more specific
+        expect(function() {
+          gradients.parse('linear-gradient(to right, red calc(50% + (25px), blue)');
+        }).to.throwException();
+        
+        expect(function() {
+          gradients.parse('radial-gradient(circle at calc(50% + 25px, red, blue)');
+        }).to.throwException(/Missing comma before color stops/);
+        
+        expect(function() {
+          gradients.parse('linear-gradient(90deg, yellow calc(100% - (50px - 20px), green)');
+        }).to.throwException();
+      });
     });
   });
 


### PR DESCRIPTION
This PR adds support for CSS calc() expressions in gradient positions.

- Added token for calc expressions
- Implemented parsing logic for calc expressions with balanced parentheses
- Added stringify support for calc nodes
- Added comprehensive tests for calc expressions in gradients

Fixes #14