### PR TITLE
Fix issue #10: Support for radial gradients with 'at' position syntax

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -358,12 +358,21 @@ GradientParser.parse = (function() {
           radialType.at = positionAt;
         }
       } else {
-        var defaultPosition = matchPositioning();
-        if (defaultPosition) {
+        // Check for "at" position first, which is a common browser output format
+        var atPosition = matchAtPosition();
+        if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: defaultPosition
+            at: atPosition
           };
+        } else {
+          var defaultPosition = matchPositioning();
+          if (defaultPosition) {
+            radialType = {
+              type: 'default-radial',
+              at: defaultPosition
+            };
+          }
         }
       }
     }

--- a/build/web.js
+++ b/build/web.js
@@ -168,12 +168,21 @@ GradientParser.parse = (function() {
           radialType.at = positionAt;
         }
       } else {
-        var defaultPosition = matchPositioning();
-        if (defaultPosition) {
+        // Check for "at" position first, which is a common browser output format
+        var atPosition = matchAtPosition();
+        if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: defaultPosition
+            at: atPosition
           };
+        } else {
+          var defaultPosition = matchPositioning();
+          if (defaultPosition) {
+            radialType = {
+              type: 'default-radial',
+              at: defaultPosition
+            };
+          }
         }
       }
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -166,12 +166,21 @@ GradientParser.parse = (function() {
           radialType.at = positionAt;
         }
       } else {
-        var defaultPosition = matchPositioning();
-        if (defaultPosition) {
+        // Check for "at" position first, which is a common browser output format
+        var atPosition = matchAtPosition();
+        if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: defaultPosition
+            at: atPosition
           };
+        } else {
+          var defaultPosition = matchPositioning();
+          if (defaultPosition) {
+            radialType = {
+              type: 'default-radial',
+              at: defaultPosition
+            };
+          }
         }
       }
     }

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -297,6 +297,33 @@ describe('lib/parser.js', function () {
       expect(ast[0].colorStops[5].length.type).to.equal('%');
       expect(ast[0].colorStops[5].length.value).to.equal('33.3');
     });
+
+    it('should parse radial-gradient with position only (no shape/extent)', function() {
+      const gradient = 'radial-gradient(at 57% 50%, rgb(102, 126, 234) 0%, rgb(118, 75, 162) 100%)';
+      const ast = gradients.parse(gradient);
+      
+      expect(ast[0].type).to.equal('radial-gradient');
+      
+      // Verify the orientation (position only)
+      expect(ast[0].orientation[0].type).to.equal('default-radial');
+      expect(ast[0].orientation[0].at.type).to.equal('position');
+      expect(ast[0].orientation[0].at.value.x.type).to.equal('%');
+      expect(ast[0].orientation[0].at.value.x.value).to.equal('57');
+      expect(ast[0].orientation[0].at.value.y.type).to.equal('%');
+      expect(ast[0].orientation[0].at.value.y.value).to.equal('50');
+      
+      // Verify color stops
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].value).to.eql(['102', '126', '234']);
+      expect(ast[0].colorStops[0].length.type).to.equal('%');
+      expect(ast[0].colorStops[0].length.value).to.equal('0');
+      
+      expect(ast[0].colorStops[1].type).to.equal('rgb');
+      expect(ast[0].colorStops[1].value).to.eql(['118', '75', '162']);
+      expect(ast[0].colorStops[1].length.type).to.equal('%');
+      expect(ast[0].colorStops[1].length.value).to.equal('100');
+    });
   });
 
   describe('parse gradient strings with trailing semicolons', function() {


### PR DESCRIPTION
This PR fixes issue #10 by adding support for radial gradients that use the 'at' position syntax without explicitly specifying shape/extent.

## Problem
Chrome and some other browsers may output radial gradients in the format , omitting the default values for shape and extent. The parser was not properly handling this format.

## Fix
Modified the parser's 'matchRadialOrientation' function to specifically check for gradients that start with 'at' followed by a position, handling them properly as default radial gradients with the specified position.

## Testing
Added a specific test case for the format mentioned in issue #10 to verify the fix works correctly.

Closes #10