### PR TITLE
Fix parsing of legacy gradient syntax with directional values

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -307,8 +307,24 @@ GradientParser.parse = (function() {
   }
 
   function matchLinearOrientation() {
-    return matchSideOrCorner() ||
-      matchAngle();
+    // Check for standard CSS3 "to" direction
+    var sideOrCorner = matchSideOrCorner();
+    if (sideOrCorner) {
+      return sideOrCorner;
+    }
+    
+    // Check for legacy single keyword direction (e.g., "right", "top")
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    if (legacyDirection) {
+      // For legacy syntax, we convert to the directional type
+      return {
+        type: 'directional',
+        value: legacyDirection.value
+      };
+    }
+    
+    // If neither, check for angle
+    return matchAngle();
   }
 
   function matchSideOrCorner() {

--- a/build/node.js
+++ b/build/node.js
@@ -314,7 +314,7 @@ GradientParser.parse = (function() {
     }
     
     // Check for legacy single keyword direction (e.g., "right", "top")
-    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 1);
     if (legacyDirection) {
       // For legacy syntax, we convert to the directional type
       return {

--- a/build/web.js
+++ b/build/web.js
@@ -117,8 +117,24 @@ GradientParser.parse = (function() {
   }
 
   function matchLinearOrientation() {
-    return matchSideOrCorner() ||
-      matchAngle();
+    // Check for standard CSS3 "to" direction
+    var sideOrCorner = matchSideOrCorner();
+    if (sideOrCorner) {
+      return sideOrCorner;
+    }
+    
+    // Check for legacy single keyword direction (e.g., "right", "top")
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    if (legacyDirection) {
+      // For legacy syntax, we convert to the directional type
+      return {
+        type: 'directional',
+        value: legacyDirection.value
+      };
+    }
+    
+    // If neither, check for angle
+    return matchAngle();
   }
 
   function matchSideOrCorner() {

--- a/build/web.js
+++ b/build/web.js
@@ -124,7 +124,7 @@ GradientParser.parse = (function() {
     }
     
     // Check for legacy single keyword direction (e.g., "right", "top")
-    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 1);
     if (legacyDirection) {
       // For legacy syntax, we convert to the directional type
       return {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -115,8 +115,24 @@ GradientParser.parse = (function() {
   }
 
   function matchLinearOrientation() {
-    return matchSideOrCorner() ||
-      matchAngle();
+    // Check for standard CSS3 "to" direction
+    var sideOrCorner = matchSideOrCorner();
+    if (sideOrCorner) {
+      return sideOrCorner;
+    }
+    
+    // Check for legacy single keyword direction (e.g., "right", "top")
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    if (legacyDirection) {
+      // For legacy syntax, we convert to the directional type
+      return {
+        type: 'directional',
+        value: legacyDirection.value
+      };
+    }
+    
+    // If neither, check for angle
+    return matchAngle();
   }
 
   function matchSideOrCorner() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -122,7 +122,7 @@ GradientParser.parse = (function() {
     }
     
     // Check for legacy single keyword direction (e.g., "right", "top")
-    var legacyDirection = match('position-keyword', tokens.positionKeywords, 0);
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 1);
     if (legacyDirection) {
       // For legacy syntax, we convert to the directional type
       return {

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -153,6 +153,29 @@ describe('lib/parser.js', function () {
         });
       });
     });
+    
+    it('should correctly parse directional value without "to" keyword (legacy syntax)', function() {
+      // This uses the legacy syntax without "to" keyword (e.g., "right" instead of "to right")
+      const parsed = gradients.parse('-webkit-linear-gradient(right, rgb(248, 6, 234) 71%, rgb(202, 74, 208) 78%)');
+      subject = parsed[0];
+      
+      // It should properly identify the orientation as directional "right"
+      expect(subject.orientation).to.be.an('object');
+      expect(subject.orientation.type).to.equal('directional');
+      expect(subject.orientation.value).to.equal('right');
+      
+      // And it should have only 2 color stops
+      expect(subject.colorStops).to.have.length(2);
+      expect(subject.colorStops[0].type).to.equal('rgb');
+      expect(subject.colorStops[0].value).to.eql(['248', '6', '234']);
+      expect(subject.colorStops[0].length.type).to.equal('%');
+      expect(subject.colorStops[0].length.value).to.equal('71');
+      
+      expect(subject.colorStops[1].type).to.equal('rgb');
+      expect(subject.colorStops[1].value).to.eql(['202', '74', '208']);
+      expect(subject.colorStops[1].length.type).to.equal('%');
+      expect(subject.colorStops[1].length.value).to.equal('78');
+    });
   });
 
   describe('parse all color types', function() {

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -157,7 +157,7 @@ describe('lib/parser.js', function () {
     it('should correctly parse directional value without "to" keyword (legacy syntax)', function() {
       // This uses the legacy syntax without "to" keyword (e.g., "right" instead of "to right")
       const parsed = gradients.parse('-webkit-linear-gradient(right, rgb(248, 6, 234) 71%, rgb(202, 74, 208) 78%)');
-      subject = parsed[0];
+      let subject = parsed[0];
       
       // It should properly identify the orientation as directional "right"
       expect(subject.orientation).to.be.an('object');
@@ -180,7 +180,7 @@ describe('lib/parser.js', function () {
     // Additional test cases for other legacy directional keywords
     it('should correctly parse legacy syntax with "top" direction', function() {
       const parsed = gradients.parse('-webkit-linear-gradient(top, #ff0000, #0000ff)');
-      subject = parsed[0];
+      let subject = parsed[0];
       
       expect(subject.orientation).to.be.an('object');
       expect(subject.orientation.type).to.equal('directional');
@@ -195,7 +195,7 @@ describe('lib/parser.js', function () {
     
     it('should correctly parse legacy syntax with "left" direction', function() {
       const parsed = gradients.parse('-webkit-linear-gradient(left, rgba(255, 0, 0, 0.5), rgba(0, 0, 255, 0.8))');
-      subject = parsed[0];
+      let subject = parsed[0];
       
       expect(subject.orientation).to.be.an('object');
       expect(subject.orientation.type).to.equal('directional');
@@ -210,7 +210,7 @@ describe('lib/parser.js', function () {
     
     it('should correctly parse legacy syntax with "bottom" direction', function() {
       const parsed = gradients.parse('-webkit-linear-gradient(bottom, hsla(0, 100%, 50%, 0.3), hsla(240, 100%, 50%, 0.7))');
-      subject = parsed[0];
+      let subject = parsed[0];
       
       expect(subject.orientation).to.be.an('object');
       expect(subject.orientation.type).to.equal('directional');

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -176,6 +176,52 @@ describe('lib/parser.js', function () {
       expect(subject.colorStops[1].length.type).to.equal('%');
       expect(subject.colorStops[1].length.value).to.equal('78');
     });
+    
+    // Additional test cases for other legacy directional keywords
+    it('should correctly parse legacy syntax with "top" direction', function() {
+      const parsed = gradients.parse('-webkit-linear-gradient(top, #ff0000, #0000ff)');
+      subject = parsed[0];
+      
+      expect(subject.orientation).to.be.an('object');
+      expect(subject.orientation.type).to.equal('directional');
+      expect(subject.orientation.value).to.equal('top');
+      
+      expect(subject.colorStops).to.have.length(2);
+      expect(subject.colorStops[0].type).to.equal('hex');
+      expect(subject.colorStops[0].value).to.equal('ff0000');
+      expect(subject.colorStops[1].type).to.equal('hex');
+      expect(subject.colorStops[1].value).to.equal('0000ff');
+    });
+    
+    it('should correctly parse legacy syntax with "left" direction', function() {
+      const parsed = gradients.parse('-webkit-linear-gradient(left, rgba(255, 0, 0, 0.5), rgba(0, 0, 255, 0.8))');
+      subject = parsed[0];
+      
+      expect(subject.orientation).to.be.an('object');
+      expect(subject.orientation.type).to.equal('directional');
+      expect(subject.orientation.value).to.equal('left');
+      
+      expect(subject.colorStops).to.have.length(2);
+      expect(subject.colorStops[0].type).to.equal('rgba');
+      expect(subject.colorStops[0].value).to.eql(['255', '0', '0', '0.5']);
+      expect(subject.colorStops[1].type).to.equal('rgba');
+      expect(subject.colorStops[1].value).to.eql(['0', '0', '255', '0.8']);
+    });
+    
+    it('should correctly parse legacy syntax with "bottom" direction', function() {
+      const parsed = gradients.parse('-webkit-linear-gradient(bottom, hsla(0, 100%, 50%, 0.3), hsla(240, 100%, 50%, 0.7))');
+      subject = parsed[0];
+      
+      expect(subject.orientation).to.be.an('object');
+      expect(subject.orientation.type).to.equal('directional');
+      expect(subject.orientation.value).to.equal('bottom');
+      
+      expect(subject.colorStops).to.have.length(2);
+      expect(subject.colorStops[0].type).to.equal('hsla');
+      expect(subject.colorStops[0].value).to.eql(['0', '100', '50', '0.3']);
+      expect(subject.colorStops[1].type).to.equal('hsla');
+      expect(subject.colorStops[1].value).to.eql(['240', '100', '50', '0.7']);
+    });
   });
 
   describe('parse all color types', function() {


### PR DESCRIPTION
Fixes #6

This PR fixes an issue with the parser incorrectly handling directional values in legacy gradient syntax (without the 'to' keyword).

For example, in '-webkit-linear-gradient(right, rgb(248, 6, 234) 71%, rgb(202, 74, 208) 78%)', 'right' was being parsed as a color stop instead of a directional orientation.

The fix includes:
- Modified the matchLinearOrientation function to detect legacy directional keywords
- Added a test case to verify the fix
- Rebuilt the node.js and web.js files with the changes