### PR TITLE
Fix issue #9: Remove unused result parameter from visit_array

### DIFF
--- a/build/node.js
+++ b/build/node.js
@@ -168,7 +168,7 @@ GradientParser.stringify = (function() {
       var result = '';
 
       if (element instanceof Array) {
-        return visitor.visit_array(element, result);
+        return visitor.visit_array(element);
       } else if (typeof element === 'object' && !element.type) {
         return visitor.visit_object(element);
       } else if (element.type) {

--- a/build/web.js
+++ b/build/web.js
@@ -655,7 +655,7 @@ GradientParser.stringify = (function() {
       var result = '';
 
       if (element instanceof Array) {
-        return visitor.visit_array(element, result);
+        return visitor.visit_array(element);
       } else if (typeof element === 'object' && !element.type) {
         return visitor.visit_object(element);
       } else if (element.type) {

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -168,7 +168,7 @@ GradientParser.stringify = (function() {
       var result = '';
 
       if (element instanceof Array) {
-        return visitor.visit_array(element, result);
+        return visitor.visit_array(element);
       } else if (typeof element === 'object' && !element.type) {
         return visitor.visit_object(element);
       } else if (element.type) {

--- a/spec/stringify.spec.js
+++ b/spec/stringify.spec.js
@@ -15,6 +15,19 @@ describe('lib/stringify.js', function () {
   });
 
   describe('serialization', function() {
+    it('should handle array input without error', function() {
+      const nodes = [{
+        type: 'linear-gradient',
+        colorStops: [{ type: 'literal', value: 'red' }, { type: 'literal', value: 'blue' }],
+        orientation: null
+      }];
+      
+      expect(function() {
+        const result = gradients.stringify(nodes);
+        expect(result).to.equal('linear-gradient(red, blue)');
+      }).to.not.throwException();
+    });
+
 
     it('if tree is null', function() {
       expect(gradients.stringify(null)).to.equal('');


### PR DESCRIPTION
This PR fixes issue #9 where the visit function was passing an undefined result parameter to visit_array.

Changes made:
1. Removed the unused result parameter from the visit_array call in the visit function
2. Added a test case to verify array inputs are handled correctly without errors
3. The visit_array function wasn't using the parameter anyway, so this change is safe

The included test case verifies that array inputs to stringify (like those containing multiple gradients) work correctly.

All tests are passing.

Fixes #9