### PR TITLE
Fix bugs and add CSS feature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-Parse CSS3 gradient definition and returns AST `object`.
+Parse CSS gradient definitions and return an AST `object`. Supports linear, radial, and conic gradients including vendor-prefixed and repeating variants.
 
 ## Examples
 
@@ -22,7 +22,8 @@ Results in:
     "type": "linear-gradient",
     "orientation": {
       "type": "angular",
-      "value": "30"
+      "value": "30",
+      "unit": "deg"
     },
     "colorStops": [
       {
@@ -45,9 +46,14 @@ Install via npm:
 npm install gradient-parser
 ```
 
-Import in Node.js:
+Import in Node.js (CommonJS):
 ```javascript
 const gradient = require('gradient-parser');
+```
+
+Import in Node.js (ESM):
+```javascript
+import { parse, stringify } from 'gradient-parser';
 ```
 
 For browser usage:
@@ -94,6 +100,8 @@ Run the test suite with:
 npm test
 ```
 
+The build step runs automatically before tests via the `pretest` script.
+
 ### Starting a local server
 
 You can run a simple HTTP server for development:
@@ -104,9 +112,27 @@ npm start
 
 ## API
 
-### gradient.parse
+### gradient.parse(gradientString)
 
-Accepts the gradient definitions as it is declared in `background-image` and returns an AST `object`.
+Accepts a CSS gradient definition as declared in `background-image` and returns an AST as an `Array` of gradient nodes.
+
+```javascript
+var ast = gradient.parse('linear-gradient(to right, red, blue)');
+```
+
+### gradient.stringify(ast)
+
+Accepts an AST (as returned by `parse`) and serializes it back into a CSS gradient string.
+
+```javascript
+var css = gradient.stringify(ast);
+// => 'linear-gradient(to right, red, blue)'
+```
+
+Round-trip is supported:
+```javascript
+gradient.stringify(gradient.parse(input)) === input
+```
 
 ## AST
 
@@ -116,7 +142,7 @@ All nodes have the following properties.
 
 #### type
 
-`String`. The possible values are the ones listed in the Types section bellow.
+`String`. The possible values are the ones listed in the Types section below.
 
 ### Types
 
@@ -124,31 +150,56 @@ The available values of `node.type` are listed below, as well as the available p
 
 ### linear-gradient
 
-- orientation: `Object` possible types `directional` or `angular`.
-- colorStops: `Array` of color stops of type `literal`, `hex`, `rgb`, or `rgba`.
+- orientation: `Object` or `undefined`. Possible types `directional` or `angular`.
+- colorStops: `Array` of color stops.
 
 ### repeating-linear-gradient
 
-- orientation: `Object` possible types `directional` or `angular`.
-- colorStops: `Array` of color stops of type `literal`, `hex`, `rgb`, or `rgba`.
+- orientation: `Object` or `undefined`. Possible types `directional` or `angular`.
+- colorStops: `Array` of color stops.
 
 ### radial-gradient
 
-- orientation: `Array` or `undefined`. `Array` of possible types `shape`, `default-radial`.
-- colorStops: `Array` of color stops of type `literal`, `hex`, `rgb`, or `rgba`.
+- orientation: `Array` or `undefined`. `Array` of possible types `shape`, `default-radial`, `extent-keyword`.
+- colorStops: `Array` of color stops.
 
 ### repeating-radial-gradient
 
-- orientation: `Array` or `undefined`. `Array` of possible types `shape`, `default-radial`.
-- colorStops: `Array` of color stops of type `literal`, `hex`, `rgb`, or `rgba`.
+- orientation: `Array` or `undefined`. `Array` of possible types `shape`, `default-radial`, `extent-keyword`.
+- colorStops: `Array` of color stops.
+
+### conic-gradient
+
+- orientation: `Object` or `undefined` of type `conic`.
+- colorStops: `Array` of color stops.
+
+### repeating-conic-gradient
+
+- orientation: `Object` or `undefined` of type `conic`.
+- colorStops: `Array` of color stops.
+
+### Color Stops
+
+Each color stop has the following properties:
+
+- type: `String` one of `literal`, `hex`, `rgb`, `rgba`, `hsl`, `hsla`, `var`.
+- value: the color value (type varies, see color types below).
+- length: `Object` or `undefined`. Position of the color stop (see length types).
+- length2: `Object` or `undefined`. Second position for dual-position color stops.
 
 ### directional
 
-- value: `String` possible values `left`, `top`, `bottom`, or `right`.
+- value: `String` possible values `left`, `top`, `bottom`, `right`, `left top`, `left bottom`, `right top`, `right bottom`, `top left`, `top right`, `bottom left`, `bottom right`.
 
 ### angular
 
-- value: `Number` integer number.
+- value: `String` numeric value of the angle.
+- unit: `String` one of `deg`, `rad`, `grad`, `turn`.
+
+### conic
+
+- angle: `Object` or `undefined` of type `angular`.
+- at: `Object` or `undefined` of type `position`.
 
 ### literal
 
@@ -156,37 +207,60 @@ The available values of `node.type` are listed below, as well as the available p
 
 ### hex
 
-- value: `String` hex value.
+- value: `String` hex value (3, 4, 6, or 8 digits, without `#` prefix).
 
 ### rgb
 
-- value: `Array` of length 3 of `Number`'s.
+- value: `Array` of length 3 of `String` numbers.
 
 ### rgba
 
-- value: `Array` of length 4 or `Number`'s.
+- value: `Array` of length 4 of `String` numbers.
+
+### hsl
+
+- value: `Array` of length 3: `[hue, saturation, lightness]`. Hue is a `String` number, saturation and lightness are `String` numbers without the `%` suffix.
+
+### hsla
+
+- value: `Array` of length 4: `[hue, saturation, lightness, alpha]`. Same as `hsl` with an additional alpha `String` number.
+
+### var
+
+- value: `String` the CSS custom property name (e.g. `--color-red`).
+
+### calc
+
+- type: `'calc'`
+- value: `String` the raw calc expression content (e.g. `50% + 25px`).
 
 ### shape
 
-- style: `Object` or `undefined` possible types `extent-keyword`, `px`, `em`, `%`, or `positioning-keyword`.
+- style: `Object` or `undefined` possible types `extent-keyword`, `px`, `em`, `rem`, `%`, `position`, or `position-keyword`.
 - value: `String` possible values `ellipse` or `circle`.
-- at: `Object` of attributes:
-	- x: `Object` possible types `extent-keyword`, `px`, `em`, `%`, or `positioning-keyword`.
-	- y: `Object` possible types `extent-keyword`, `px`, `em`, `%`, or `positioning-keyword`.
+- at: `Object` or `undefined` of type `position`.
 
 ### default-radial
 
-- at: `Object` of attributes:
-	- x: `Object` possible types `extent-keyword`, `px`, `em`, `%`, or `positioning-keyword`.
-	- y: `Object` possible types `extent-keyword`, `px`, `em`, `%`, or `positioning-keyword`.
+- at: `Object` of type `position`.
 
-### positioning-keyword
+### position
+
+- value: `Object` with `x` and `y` properties, each a length/keyword node.
+
+### position-keyword
 
 - value: `String` possible values `center`, `left`, `top`, `bottom`, or `right`.
 
 ### extent-keyword
 
 - value: `String` possible values `closest-side`, `closest-corner`, `farthest-side`, `farthest-corner`, `contain`, or `cover`.
+
+### Length types
+
+Length nodes can be any of: `px`, `em`, `rem`, `vw`, `vh`, `vmin`, `vmax`, `ch`, `ex`, `%`, `calc`.
+
+- value: `String` numeric value (for `calc`, the expression string).
 
 ## License
 

--- a/build.js
+++ b/build.js
@@ -79,6 +79,26 @@ async function build() {
     }
   }
 
+  // Build ESM entry point (always, when building node)
+  if (buildNode) {
+    console.log('Building esm.mjs bundle...');
+
+    const stringifyContent = fs.readFileSync(path.join(__dirname, 'lib', 'stringify.js'), 'utf8');
+    const parserContent = fs.readFileSync(path.join(__dirname, 'lib', 'parser.js'), 'utf8');
+
+    const esmBundle = `${stringifyContent}\n${parserContent}\nexport const parse = GradientParser.parse;\nexport const stringify = GradientParser.stringify;\nexport default { parse: GradientParser.parse, stringify: GradientParser.stringify };\n`;
+
+    const esmOutputPath = path.join(__dirname, 'build', 'esm.mjs');
+
+    if (minify) {
+      await minifyCode(esmBundle, esmOutputPath);
+      console.log('✓ ESM bundle created and minified successfully');
+    } else {
+      fs.writeFileSync(esmOutputPath, esmBundle);
+      console.log('✓ ESM bundle created successfully');
+    }
+  }
+
   // If no arguments were provided, we built both bundles
   if (!args.length) {
     console.log('✓ All bundles built successfully');

--- a/build/esm.mjs
+++ b/build/esm.mjs
@@ -1,0 +1,834 @@
+// Copyright (c) 2014 Rafael Caricio. All rights reserved.
+// Use of this source code is governed by an MIT license that can be
+// found in the LICENSE file.
+
+var GradientParser = (GradientParser || {});
+
+GradientParser.stringify = (function() {
+
+  var visitor = {
+
+    'visit_linear-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-linear-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_radial-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-radial-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_conic-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-conic-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_gradient': function(node) {
+      var orientation = visitor.visit(node.orientation);
+      if (orientation) {
+        orientation += ', ';
+      }
+
+      return node.type + '(' + orientation + visitor.visit(node.colorStops) + ')';
+    },
+
+    'visit_shape': function(node) {
+      var result = node.value,
+          at = visitor.visit(node.at),
+          style = visitor.visit(node.style);
+
+      if (style) {
+        result += ' ' + style;
+      }
+
+      if (at) {
+        result += ' at ' + at;
+      }
+
+      return result;
+    },
+
+    'visit_default-radial': function(node) {
+      var result = '',
+          at = visitor.visit(node.at);
+
+      if (at) {
+        if (node.hasAtKeyword) {
+          result += 'at ' + at;
+        } else {
+          result += at;
+        }
+      }
+      return result;
+    },
+
+    'visit_extent-keyword': function(node) {
+      var result = node.value,
+          at = visitor.visit(node.at);
+
+      if (at) {
+        result += ' at ' + at;
+      }
+
+      return result;
+    },
+
+    'visit_position-keyword': function(node) {
+      return node.value;
+    },
+
+    'visit_position': function(node) {
+      return visitor.visit(node.value.x) + ' ' + visitor.visit(node.value.y);
+    },
+
+    'visit_%': function(node) {
+      return node.value + '%';
+    },
+
+    'visit_em': function(node) {
+      return node.value + 'em';
+    },
+
+    'visit_px': function(node) {
+      return node.value + 'px';
+    },
+
+    'visit_rem': function(node) {
+      return node.value + 'rem';
+    },
+
+    'visit_vw': function(node) {
+      return node.value + 'vw';
+    },
+
+    'visit_vh': function(node) {
+      return node.value + 'vh';
+    },
+
+    'visit_vmin': function(node) {
+      return node.value + 'vmin';
+    },
+
+    'visit_vmax': function(node) {
+      return node.value + 'vmax';
+    },
+
+    'visit_ch': function(node) {
+      return node.value + 'ch';
+    },
+
+    'visit_ex': function(node) {
+      return node.value + 'ex';
+    },
+
+    'visit_calc': function(node) {
+      return 'calc(' + node.value + ')';
+    },
+
+    'visit_literal': function(node) {
+      return visitor.visit_color(node.value, node);
+    },
+
+    'visit_hex': function(node) {
+      return visitor.visit_color('#' + node.value, node);
+    },
+
+    'visit_rgb': function(node) {
+      return visitor.visit_color('rgb(' + node.value.join(', ') + ')', node);
+    },
+
+    'visit_rgba': function(node) {
+      return visitor.visit_color('rgba(' + node.value.join(', ') + ')', node);
+    },
+
+    'visit_hsl': function(node) {
+      return visitor.visit_color('hsl(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%)', node);
+    },
+
+    'visit_hsla': function(node) {
+      return visitor.visit_color('hsla(' + node.value[0] + ', ' + node.value[1] + '%, ' + node.value[2] + '%, ' + node.value[3] + ')', node);
+    },
+
+    'visit_var': function(node) {
+      return visitor.visit_color('var(' + node.value + ')', node);
+    },
+
+    'visit_color': function(resultColor, node) {
+      var result = resultColor,
+          length = visitor.visit(node.length);
+
+      if (length) {
+        result += ' ' + length;
+      }
+      var length2 = visitor.visit(node.length2);
+      if (length2) {
+        result += ' ' + length2;
+      }
+      return result;
+    },
+
+    'visit_angular': function(node) {
+      return node.value + (node.unit || 'deg');
+    },
+
+    'visit_directional': function(node) {
+      return 'to ' + node.value;
+    },
+
+    'visit_conic': function(node) {
+      var result = '';
+      if (node.angle) {
+        result += 'from ' + visitor.visit(node.angle);
+      }
+      if (node.at) {
+        if (result) {
+          result += ' ';
+        }
+        result += 'at ' + visitor.visit(node.at);
+      }
+      return result;
+    },
+
+    'visit_array': function(elements) {
+      var result = '',
+          size = elements.length;
+
+      elements.forEach(function(element, i) {
+        result += visitor.visit(element);
+        if (i < size - 1) {
+          result += ', ';
+        }
+      });
+
+      return result;
+    },
+
+    'visit_object': function(obj) {
+      if (obj.width && obj.height) {
+        return visitor.visit(obj.width) + ' ' + visitor.visit(obj.height);
+      }
+      return '';
+    },
+
+    'visit': function(element) {
+      if (!element) {
+        return '';
+      }
+      var result = '';
+
+      if (element instanceof Array) {
+        return visitor.visit_array(element);
+      } else if (typeof element === 'object' && !element.type) {
+        return visitor.visit_object(element);
+      } else if (element.type) {
+        var nodeVisitor = visitor['visit_' + element.type];
+        if (nodeVisitor) {
+          return nodeVisitor(element);
+        } else {
+          throw Error('Missing visitor visit_' + element.type);
+        }
+      } else {
+        throw Error('Invalid node.');
+      }
+    }
+
+  };
+
+  return function(root) {
+    return visitor.visit(root);
+  };
+})();
+
+// Copyright (c) 2014 Rafael Caricio. All rights reserved.
+// Use of this source code is governed by an MIT license that can be
+// found in the LICENSE file.
+
+var GradientParser = (GradientParser || {});
+
+GradientParser.parse = (function() {
+
+  var tokens = {
+    linearGradient: /^(\-(webkit|o|ms|moz)\-)?(linear\-gradient)/i,
+    repeatingLinearGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-linear\-gradient)/i,
+    radialGradient: /^(\-(webkit|o|ms|moz)\-)?(radial\-gradient)/i,
+    repeatingRadialGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-radial\-gradient)/i,
+    conicGradient: /^(\-(webkit|o|ms|moz)\-)?(conic\-gradient)/i,
+    repeatingConicGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-conic\-gradient)/i,
+    sideOrCorner: /^to (left (top|bottom)|right (top|bottom)|top (left|right)|bottom (left|right)|left|right|top|bottom)/i,
+    extentKeywords: /^(closest\-side|closest\-corner|farthest\-side|farthest\-corner|contain|cover)/,
+    positionKeywords: /^(left|center|right|top|bottom)/i,
+    pixelValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))px/,
+    percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
+    emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
+    remValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rem/,
+    vwValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vw/,
+    vhValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vh/,
+    vminValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmin/,
+    vmaxValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmax/,
+    chValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ch/,
+    exValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ex/,
+    angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
+    radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
+    gradianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))grad/,
+    turnValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))turn/,
+    startCall: /^\(/,
+    endCall: /^\)/,
+    comma: /^,/,
+    slash: /^\//,
+    hexColor: /^\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/,
+    literalColor: /^([a-zA-Z]+)/,
+    rgbColor: /^rgb/i,
+    rgbaColor: /^rgba/i,
+    varColor: /^var/i,
+    calcValue: /^calc/i,
+    variableName: /^(--[a-zA-Z0-9-,\s\#]+)/,
+    number: /^(([0-9]*\.[0-9]+)|([0-9]+\.?))/,
+    hslColor: /^hsl/i,
+    hslaColor: /^hsla/i,
+  };
+
+  var input = '';
+
+  function error(msg) {
+    var err = new Error(input + ': ' + msg);
+    err.source = input;
+    throw err;
+  }
+
+  function getAST() {
+    var ast = matchListDefinitions();
+
+    if (input.length > 0) {
+      error('Invalid input not EOF');
+    }
+
+    return ast;
+  }
+
+  function matchListDefinitions() {
+    return matchListing(matchDefinition);
+  }
+
+  function matchDefinition() {
+    return matchGradient(
+            'linear-gradient',
+            tokens.linearGradient,
+            matchLinearOrientation) ||
+
+          matchGradient(
+            'repeating-linear-gradient',
+            tokens.repeatingLinearGradient,
+            matchLinearOrientation) ||
+
+          matchGradient(
+            'radial-gradient',
+            tokens.radialGradient,
+            matchListRadialOrientations) ||
+
+          matchGradient(
+            'repeating-radial-gradient',
+            tokens.repeatingRadialGradient,
+            matchListRadialOrientations) ||
+
+          matchGradient(
+            'conic-gradient',
+            tokens.conicGradient,
+            matchConicOrientation) ||
+
+          matchGradient(
+            'repeating-conic-gradient',
+            tokens.repeatingConicGradient,
+            matchConicOrientation);
+  }
+
+  function matchGradient(gradientType, pattern, orientationMatcher) {
+    return matchCall(pattern, function(captures) {
+
+      var orientation = orientationMatcher();
+      if (orientation) {
+        if (!scan(tokens.comma)) {
+          error('Missing comma before color stops');
+        }
+      }
+
+      return {
+        type: gradientType,
+        orientation: orientation,
+        colorStops: matchListing(matchColorStop)
+      };
+    });
+  }
+
+  function matchCall(pattern, callback) {
+    var captures = scan(pattern);
+
+    if (captures) {
+      if (!scan(tokens.startCall)) {
+        error('Missing (');
+      }
+
+      var result = callback(captures);
+
+      if (!scan(tokens.endCall)) {
+        error('Missing )');
+      }
+
+      return result;
+    }
+  }
+
+  function matchLinearOrientation() {
+    // Check for standard CSS3 "to" direction
+    var sideOrCorner = matchSideOrCorner();
+    if (sideOrCorner) {
+      return sideOrCorner;
+    }
+    
+    // Check for legacy single keyword direction (e.g., "right", "top")
+    var legacyDirection = match('position-keyword', tokens.positionKeywords, 1);
+    if (legacyDirection) {
+      // For legacy syntax, we convert to the directional type
+      return {
+        type: 'directional',
+        value: legacyDirection.value
+      };
+    }
+    
+    // If neither, check for angle
+    return matchAngle();
+  }
+
+  function matchConicOrientation() {
+    var angle = matchFrom();
+    var atPosition = matchAtPosition();
+
+    if (angle || atPosition) {
+      return {
+        type: 'conic',
+        angle: angle || undefined,
+        at: atPosition || undefined
+      };
+    }
+  }
+
+  function matchFrom() {
+    if (match('from', /^from/, 0)) {
+      var angle = matchAngle();
+      if (!angle) {
+        error('Missing angle after "from" in conic-gradient');
+      }
+      return angle;
+    }
+  }
+
+  function matchSideOrCorner() {
+    return match('directional', tokens.sideOrCorner, 1);
+  }
+
+  function matchAngle() {
+    return matchAngularWithUnit('deg', tokens.angleValue) ||
+      matchAngularWithUnit('rad', tokens.radianValue) ||
+      matchAngularWithUnit('grad', tokens.gradianValue) ||
+      matchAngularWithUnit('turn', tokens.turnValue);
+  }
+
+  function matchAngularWithUnit(unit, pattern) {
+    var captures = scan(pattern);
+    if (captures) {
+      return {
+        type: 'angular',
+        value: captures[1],
+        unit: unit
+      };
+    }
+  }
+
+  function matchListRadialOrientations() {
+    var radialOrientations,
+        radialOrientation = matchRadialOrientation(),
+        lookaheadCache;
+
+    if (radialOrientation) {
+      radialOrientations = [];
+      radialOrientations.push(radialOrientation);
+
+      lookaheadCache = input;
+      if (scan(tokens.comma)) {
+        radialOrientation = matchRadialOrientation();
+        if (radialOrientation) {
+          radialOrientations.push(radialOrientation);
+        } else {
+          input = lookaheadCache;
+        }
+      }
+    }
+
+    return radialOrientations;
+  }
+
+  function matchRadialOrientation() {
+    var radialType = matchCircle() ||
+      matchEllipse();
+
+    if (radialType) {
+      radialType.at = matchAtPosition();
+    } else {
+      var extent = matchExtentKeyword();
+      if (extent) {
+        radialType = extent;
+        var positionAt = matchAtPosition();
+        if (positionAt) {
+          radialType.at = positionAt;
+        }
+      } else {
+        // Check for "at" position first, which is a common browser output format
+        var atPosition = matchAtPosition();
+        if (atPosition) {
+          radialType = {
+            type: 'default-radial',
+            at: atPosition,
+            hasAtKeyword: true
+          };
+        } else {
+          var defaultPosition = matchPositioning();
+          if (defaultPosition) {
+            radialType = {
+              type: 'default-radial',
+              at: defaultPosition
+            };
+          }
+        }
+      }
+    }
+
+    return radialType;
+  }
+
+  function matchCircle() {
+    var circle = match('shape', /^(circle)/i, 0);
+
+    if (circle) {
+      circle.style = matchLength() || matchExtentKeyword();
+    }
+
+    return circle;
+  }
+
+  function matchEllipse() {
+    var ellipse = match('shape', /^(ellipse)/i, 0);
+
+    if (ellipse) {
+      ellipse.style = matchPositioning() || matchDistance() || matchExtentKeyword();
+    }
+
+    return ellipse;
+  }
+
+  function matchExtentKeyword() {
+    return match('extent-keyword', tokens.extentKeywords, 1);
+  }
+
+  function matchAtPosition() {
+    if (match('position', /^at/, 0)) {
+      var positioning = matchPositioning();
+
+      if (!positioning) {
+        error('Missing positioning value');
+      }
+
+      return positioning;
+    }
+  }
+
+  function matchPositioning() {
+    var location = matchCoordinates();
+
+    if (location.x || location.y) {
+      return {
+        type: 'position',
+        value: location
+      };
+    }
+  }
+
+  function matchCoordinates() {
+    return {
+      x: matchDistance(),
+      y: matchDistance()
+    };
+  }
+
+  function matchListing(matcher) {
+    var captures = matcher(),
+      result = [];
+
+    if (captures) {
+      result.push(captures);
+      while (scan(tokens.comma)) {
+        captures = matcher();
+        if (captures) {
+          result.push(captures);
+        } else {
+          error('One extra comma');
+        }
+      }
+    }
+
+    return result;
+  }
+
+  function matchColorStop() {
+    var color = matchColor();
+
+    if (!color) {
+      error('Expected color definition');
+    }
+
+    color.length = matchDistance();
+    if (color.length) {
+      color.length2 = matchDistance();
+    }
+    return color;
+  }
+
+  function matchColor() {
+    return matchHexColor() ||
+      matchHSLAColor() ||
+      matchHSLColor() ||
+      matchRGBAColor() ||
+      matchRGBColor() ||
+      matchVarColor() ||
+      matchLiteralColor();
+  }
+
+  function matchLiteralColor() {
+    return match('literal', tokens.literalColor, 0);
+  }
+
+  function matchHexColor() {
+    return match('hex', tokens.hexColor, 1);
+  }
+
+  function matchRGBColor() {
+    return matchCall(tokens.rgbColor, function() {
+      return matchRGBValues('rgb');
+    });
+  }
+
+  function matchRGBAColor() {
+    return matchCall(tokens.rgbaColor, function() {
+      return matchRGBValues('rgba');
+    });
+  }
+
+  function matchRGBValues(baseType) {
+    var r = matchNumber();
+    var lookaheadCache = input;
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: rgb(r, g, b) or rgba(r, g, b, a)
+      var g = matchNumber();
+      scan(tokens.comma);
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.comma)) {
+        values.push(matchNumber());
+        return { type: baseType === 'rgba' ? 'rgba' : 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    } else {
+      // Modern space-separated syntax: rgb(r g b) or rgb(r g b / a)
+      var g = matchNumber();
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.slash)) {
+        values.push(matchNumber());
+        return { type: 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    }
+  }
+
+  function matchVarColor() {
+    return matchCall(tokens.varColor, function () {
+      return {
+        type: 'var',
+        value: matchVariableName()
+      };
+    });
+  }
+
+  function matchHSLColor() {
+    return matchCall(tokens.hslColor, function() {
+      return matchHSLValues('hsl');
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      return matchHSLValues('hsla');
+    });
+  }
+
+  function matchHSLValues(baseType) {
+    // Check for percentage before trying to parse the hue
+    var lookahead = scan(tokens.percentageValue);
+    if (lookahead) {
+      error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+    }
+
+    var hue = matchNumber();
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: hsl(h, s%, l%) or hsla(h, s%, l%, a)
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
+      scan(tokens.comma);
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSL');
+      }
+      if (scan(tokens.comma)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    } else {
+      // Modern space-separated syntax: hsl(h s% l%) or hsl(h s% l% / a)
+      var captures = scan(tokens.percentageValue);
+      var sat = captures ? captures[1] : null;
+      captures = scan(tokens.percentageValue);
+      var light = captures ? captures[1] : null;
+      if (!sat || !light) {
+        error('Expected percentage value for saturation and lightness in HSL');
+      }
+      if (scan(tokens.slash)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    }
+  }
+
+  function matchPercentage() {
+    var captures = scan(tokens.percentageValue);
+    return captures ? captures[1] : null;
+  }
+
+  function matchVariableName() {
+    return scan(tokens.variableName)[1];
+  }
+
+  function matchNumber() {
+    return scan(tokens.number)[1];
+  }
+
+  function matchDistance() {
+    return match('%', tokens.percentageValue, 1) ||
+      matchPositionKeyword() ||
+      matchCalc() ||
+      matchLength();
+  }
+
+  function matchPositionKeyword() {
+    return match('position-keyword', tokens.positionKeywords, 1);
+  }
+
+  function matchCalc() {
+    return matchCall(tokens.calcValue, function() {
+      var openParenCount = 1; // Start with the opening parenthesis from calc(
+      var i = 0;
+      
+      // Parse through the content looking for balanced parentheses
+      while (openParenCount > 0 && i < input.length) {
+        var char = input.charAt(i);
+        if (char === '(') {
+          openParenCount++;
+        } else if (char === ')') {
+          openParenCount--;
+        }
+        i++;
+      }
+      
+      // If we exited because we ran out of input but still have open parentheses, error
+      if (openParenCount > 0) {
+        error('Missing closing parenthesis in calc() expression');
+      }
+      
+      // Get the content inside the calc() without the last closing paren
+      var calcContent = input.substring(0, i - 1);
+      
+      // Consume the calc expression content
+      consume(i - 1); // -1 because we don't want to consume the closing parenthesis
+      
+      return {
+        type: 'calc',
+        value: calcContent
+      };
+    });
+  }
+
+  function matchLength() {
+    return match('px', tokens.pixelValue, 1) ||
+      match('em', tokens.emValue, 1) ||
+      match('rem', tokens.remValue, 1) ||
+      match('vw', tokens.vwValue, 1) ||
+      match('vh', tokens.vhValue, 1) ||
+      match('vmin', tokens.vminValue, 1) ||
+      match('vmax', tokens.vmaxValue, 1) ||
+      match('ch', tokens.chValue, 1) ||
+      match('ex', tokens.exValue, 1);
+  }
+
+  function match(type, pattern, captureIndex) {
+    var captures = scan(pattern);
+    if (captures) {
+      return {
+        type: type,
+        value: captures[captureIndex]
+      };
+    }
+  }
+
+  function scan(regexp) {
+    var captures,
+        blankCaptures;
+
+    blankCaptures = /^[\n\r\t\s]+/.exec(input);
+    if (blankCaptures) {
+        consume(blankCaptures[0].length);
+    }
+
+    captures = regexp.exec(input);
+    if (captures) {
+        consume(captures[0].length);
+    }
+
+    return captures;
+  }
+
+  function consume(size) {
+    input = input.substring(size);
+  }
+
+  return function(code) {
+    input = code.toString().trim();
+    // Remove trailing semicolon if present
+    if (input.endsWith(';')) {
+      input = input.slice(0, -1);
+    }
+    return getAST();
+  };
+})();
+
+export const parse = GradientParser.parse;
+export const stringify = GradientParser.stringify;
+export default { parse: GradientParser.parse, stringify: GradientParser.stringify };

--- a/build/node.js
+++ b/build/node.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -21,6 +21,14 @@ GradientParser.stringify = (function() {
     },
 
     'visit_repeating-radial-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_conic-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-conic-gradient': function(node) {
       return visitor.visit_gradient(node);
     },
 
@@ -54,7 +62,11 @@ GradientParser.stringify = (function() {
           at = visitor.visit(node.at);
 
       if (at) {
-        result += at;
+        if (node.hasAtKeyword) {
+          result += 'at ' + at;
+        } else {
+          result += at;
+        }
       }
       return result;
     },
@@ -88,6 +100,34 @@ GradientParser.stringify = (function() {
 
     'visit_px': function(node) {
       return node.value + 'px';
+    },
+
+    'visit_rem': function(node) {
+      return node.value + 'rem';
+    },
+
+    'visit_vw': function(node) {
+      return node.value + 'vw';
+    },
+
+    'visit_vh': function(node) {
+      return node.value + 'vh';
+    },
+
+    'visit_vmin': function(node) {
+      return node.value + 'vmin';
+    },
+
+    'visit_vmax': function(node) {
+      return node.value + 'vmax';
+    },
+
+    'visit_ch': function(node) {
+      return node.value + 'ch';
+    },
+
+    'visit_ex': function(node) {
+      return node.value + 'ex';
     },
 
     'visit_calc': function(node) {
@@ -129,15 +169,33 @@ GradientParser.stringify = (function() {
       if (length) {
         result += ' ' + length;
       }
+      var length2 = visitor.visit(node.length2);
+      if (length2) {
+        result += ' ' + length2;
+      }
       return result;
     },
 
     'visit_angular': function(node) {
-      return node.value + 'deg';
+      return node.value + (node.unit || 'deg');
     },
 
     'visit_directional': function(node) {
       return 'to ' + node.value;
+    },
+
+    'visit_conic': function(node) {
+      var result = '';
+      if (node.angle) {
+        result += 'from ' + visitor.visit(node.angle);
+      }
+      if (node.at) {
+        if (result) {
+          result += ' ';
+        }
+        result += 'at ' + visitor.visit(node.at);
+      }
+      return result;
     },
 
     'visit_array': function(elements) {
@@ -191,7 +249,7 @@ GradientParser.stringify = (function() {
 })();
 
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -203,18 +261,30 @@ GradientParser.parse = (function() {
     repeatingLinearGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-linear\-gradient)/i,
     radialGradient: /^(\-(webkit|o|ms|moz)\-)?(radial\-gradient)/i,
     repeatingRadialGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-radial\-gradient)/i,
+    conicGradient: /^(\-(webkit|o|ms|moz)\-)?(conic\-gradient)/i,
+    repeatingConicGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-conic\-gradient)/i,
     sideOrCorner: /^to (left (top|bottom)|right (top|bottom)|top (left|right)|bottom (left|right)|left|right|top|bottom)/i,
     extentKeywords: /^(closest\-side|closest\-corner|farthest\-side|farthest\-corner|contain|cover)/,
     positionKeywords: /^(left|center|right|top|bottom)/i,
     pixelValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))px/,
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
+    remValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rem/,
+    vwValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vw/,
+    vhValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vh/,
+    vminValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmin/,
+    vmaxValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmax/,
+    chValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ch/,
+    exValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ex/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
     radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
+    gradianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))grad/,
+    turnValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))turn/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
-    hexColor: /^\#([0-9a-fA-F]+)/,
+    slash: /^\//,
+    hexColor: /^\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/,
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
@@ -267,7 +337,17 @@ GradientParser.parse = (function() {
           matchGradient(
             'repeating-radial-gradient',
             tokens.repeatingRadialGradient,
-            matchListRadialOrientations);
+            matchListRadialOrientations) ||
+
+          matchGradient(
+            'conic-gradient',
+            tokens.conicGradient,
+            matchConicOrientation) ||
+
+          matchGradient(
+            'repeating-conic-gradient',
+            tokens.repeatingConicGradient,
+            matchConicOrientation);
   }
 
   function matchGradient(gradientType, pattern, orientationMatcher) {
@@ -327,13 +407,49 @@ GradientParser.parse = (function() {
     return matchAngle();
   }
 
+  function matchConicOrientation() {
+    var angle = matchFrom();
+    var atPosition = matchAtPosition();
+
+    if (angle || atPosition) {
+      return {
+        type: 'conic',
+        angle: angle || undefined,
+        at: atPosition || undefined
+      };
+    }
+  }
+
+  function matchFrom() {
+    if (match('from', /^from/, 0)) {
+      var angle = matchAngle();
+      if (!angle) {
+        error('Missing angle after "from" in conic-gradient');
+      }
+      return angle;
+    }
+  }
+
   function matchSideOrCorner() {
     return match('directional', tokens.sideOrCorner, 1);
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1) ||
-      match('angular', tokens.radianValue, 1);
+    return matchAngularWithUnit('deg', tokens.angleValue) ||
+      matchAngularWithUnit('rad', tokens.radianValue) ||
+      matchAngularWithUnit('grad', tokens.gradianValue) ||
+      matchAngularWithUnit('turn', tokens.turnValue);
+  }
+
+  function matchAngularWithUnit(unit, pattern) {
+    var captures = scan(pattern);
+    if (captures) {
+      return {
+        type: 'angular',
+        value: captures[1],
+        unit: unit
+      };
+    }
   }
 
   function matchListRadialOrientations() {
@@ -379,7 +495,8 @@ GradientParser.parse = (function() {
         if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: atPosition
+            at: atPosition,
+            hasAtKeyword: true
           };
         } else {
           var defaultPosition = matchPositioning();
@@ -477,6 +594,9 @@ GradientParser.parse = (function() {
     }
 
     color.length = matchDistance();
+    if (color.length) {
+      color.length2 = matchDistance();
+    }
     return color;
   }
 
@@ -500,20 +620,41 @@ GradientParser.parse = (function() {
 
   function matchRGBColor() {
     return matchCall(tokens.rgbColor, function() {
-      return  {
-        type: 'rgb',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgb');
     });
   }
 
   function matchRGBAColor() {
     return matchCall(tokens.rgbaColor, function() {
-      return  {
-        type: 'rgba',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgba');
     });
+  }
+
+  function matchRGBValues(baseType) {
+    var r = matchNumber();
+    var lookaheadCache = input;
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: rgb(r, g, b) or rgba(r, g, b, a)
+      var g = matchNumber();
+      scan(tokens.comma);
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.comma)) {
+        values.push(matchNumber());
+        return { type: baseType === 'rgba' ? 'rgba' : 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    } else {
+      // Modern space-separated syntax: rgb(r g b) or rgb(r g b / a)
+      var g = matchNumber();
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.slash)) {
+        values.push(matchNumber());
+        return { type: 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    }
   }
 
   function matchVarColor() {
@@ -527,14 +668,26 @@ GradientParser.parse = (function() {
 
   function matchHSLColor() {
     return matchCall(tokens.hslColor, function() {
-      // Check for percentage before trying to parse the hue
-      var lookahead = scan(tokens.percentageValue);
-      if (lookahead) {
-        error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
-      }
-      
-      var hue = matchNumber();
-      scan(tokens.comma);
+      return matchHSLValues('hsl');
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      return matchHSLValues('hsla');
+    });
+  }
+
+  function matchHSLValues(baseType) {
+    // Check for percentage before trying to parse the hue
+    var lookahead = scan(tokens.percentageValue);
+    if (lookahead) {
+      error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+    }
+
+    var hue = matchNumber();
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: hsl(h, s%, l%) or hsla(h, s%, l%, a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
       scan(tokens.comma);
@@ -543,32 +696,26 @@ GradientParser.parse = (function() {
       if (!sat || !light) {
         error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsl',
-        value: [hue, sat, light]
-      };
-    });
-  }
-
-  function matchHSLAColor() {
-    return matchCall(tokens.hslaColor, function() {
-      var hue = matchNumber();
-      scan(tokens.comma);
+      if (scan(tokens.comma)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    } else {
+      // Modern space-separated syntax: hsl(h s% l%) or hsl(h s% l% / a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
-      scan(tokens.comma);
       captures = scan(tokens.percentageValue);
       var light = captures ? captures[1] : null;
-      scan(tokens.comma);
-      var alpha = matchNumber();
       if (!sat || !light) {
-        error('Expected percentage value for saturation and lightness in HSLA');
+        error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsla',
-        value: [hue, sat, light, alpha]
-      };
-    });
+      if (scan(tokens.slash)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    }
   }
 
   function matchPercentage() {
@@ -631,7 +778,14 @@ GradientParser.parse = (function() {
 
   function matchLength() {
     return match('px', tokens.pixelValue, 1) ||
-      match('em', tokens.emValue, 1);
+      match('em', tokens.emValue, 1) ||
+      match('rem', tokens.remValue, 1) ||
+      match('vw', tokens.vwValue, 1) ||
+      match('vh', tokens.vhValue, 1) ||
+      match('vmin', tokens.vminValue, 1) ||
+      match('vmax', tokens.vmaxValue, 1) ||
+      match('ch', tokens.chValue, 1) ||
+      match('ex', tokens.exValue, 1);
   }
 
   function match(type, pattern, captureIndex) {
@@ -662,7 +816,7 @@ GradientParser.parse = (function() {
   }
 
   function consume(size) {
-    input = input.substr(size);
+    input = input.substring(size);
   }
 
   return function(code) {

--- a/build/web.js
+++ b/build/web.js
@@ -1,7 +1,7 @@
 var GradientParser = (window.GradientParser || {});
 
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -13,18 +13,30 @@ GradientParser.parse = (function() {
     repeatingLinearGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-linear\-gradient)/i,
     radialGradient: /^(\-(webkit|o|ms|moz)\-)?(radial\-gradient)/i,
     repeatingRadialGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-radial\-gradient)/i,
+    conicGradient: /^(\-(webkit|o|ms|moz)\-)?(conic\-gradient)/i,
+    repeatingConicGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-conic\-gradient)/i,
     sideOrCorner: /^to (left (top|bottom)|right (top|bottom)|top (left|right)|bottom (left|right)|left|right|top|bottom)/i,
     extentKeywords: /^(closest\-side|closest\-corner|farthest\-side|farthest\-corner|contain|cover)/,
     positionKeywords: /^(left|center|right|top|bottom)/i,
     pixelValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))px/,
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
+    remValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rem/,
+    vwValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vw/,
+    vhValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vh/,
+    vminValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmin/,
+    vmaxValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmax/,
+    chValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ch/,
+    exValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ex/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
     radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
+    gradianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))grad/,
+    turnValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))turn/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
-    hexColor: /^\#([0-9a-fA-F]+)/,
+    slash: /^\//,
+    hexColor: /^\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/,
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
@@ -77,7 +89,17 @@ GradientParser.parse = (function() {
           matchGradient(
             'repeating-radial-gradient',
             tokens.repeatingRadialGradient,
-            matchListRadialOrientations);
+            matchListRadialOrientations) ||
+
+          matchGradient(
+            'conic-gradient',
+            tokens.conicGradient,
+            matchConicOrientation) ||
+
+          matchGradient(
+            'repeating-conic-gradient',
+            tokens.repeatingConicGradient,
+            matchConicOrientation);
   }
 
   function matchGradient(gradientType, pattern, orientationMatcher) {
@@ -137,13 +159,49 @@ GradientParser.parse = (function() {
     return matchAngle();
   }
 
+  function matchConicOrientation() {
+    var angle = matchFrom();
+    var atPosition = matchAtPosition();
+
+    if (angle || atPosition) {
+      return {
+        type: 'conic',
+        angle: angle || undefined,
+        at: atPosition || undefined
+      };
+    }
+  }
+
+  function matchFrom() {
+    if (match('from', /^from/, 0)) {
+      var angle = matchAngle();
+      if (!angle) {
+        error('Missing angle after "from" in conic-gradient');
+      }
+      return angle;
+    }
+  }
+
   function matchSideOrCorner() {
     return match('directional', tokens.sideOrCorner, 1);
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1) ||
-      match('angular', tokens.radianValue, 1);
+    return matchAngularWithUnit('deg', tokens.angleValue) ||
+      matchAngularWithUnit('rad', tokens.radianValue) ||
+      matchAngularWithUnit('grad', tokens.gradianValue) ||
+      matchAngularWithUnit('turn', tokens.turnValue);
+  }
+
+  function matchAngularWithUnit(unit, pattern) {
+    var captures = scan(pattern);
+    if (captures) {
+      return {
+        type: 'angular',
+        value: captures[1],
+        unit: unit
+      };
+    }
   }
 
   function matchListRadialOrientations() {
@@ -189,7 +247,8 @@ GradientParser.parse = (function() {
         if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: atPosition
+            at: atPosition,
+            hasAtKeyword: true
           };
         } else {
           var defaultPosition = matchPositioning();
@@ -287,6 +346,9 @@ GradientParser.parse = (function() {
     }
 
     color.length = matchDistance();
+    if (color.length) {
+      color.length2 = matchDistance();
+    }
     return color;
   }
 
@@ -310,20 +372,41 @@ GradientParser.parse = (function() {
 
   function matchRGBColor() {
     return matchCall(tokens.rgbColor, function() {
-      return  {
-        type: 'rgb',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgb');
     });
   }
 
   function matchRGBAColor() {
     return matchCall(tokens.rgbaColor, function() {
-      return  {
-        type: 'rgba',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgba');
     });
+  }
+
+  function matchRGBValues(baseType) {
+    var r = matchNumber();
+    var lookaheadCache = input;
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: rgb(r, g, b) or rgba(r, g, b, a)
+      var g = matchNumber();
+      scan(tokens.comma);
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.comma)) {
+        values.push(matchNumber());
+        return { type: baseType === 'rgba' ? 'rgba' : 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    } else {
+      // Modern space-separated syntax: rgb(r g b) or rgb(r g b / a)
+      var g = matchNumber();
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.slash)) {
+        values.push(matchNumber());
+        return { type: 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    }
   }
 
   function matchVarColor() {
@@ -337,14 +420,26 @@ GradientParser.parse = (function() {
 
   function matchHSLColor() {
     return matchCall(tokens.hslColor, function() {
-      // Check for percentage before trying to parse the hue
-      var lookahead = scan(tokens.percentageValue);
-      if (lookahead) {
-        error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
-      }
-      
-      var hue = matchNumber();
-      scan(tokens.comma);
+      return matchHSLValues('hsl');
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      return matchHSLValues('hsla');
+    });
+  }
+
+  function matchHSLValues(baseType) {
+    // Check for percentage before trying to parse the hue
+    var lookahead = scan(tokens.percentageValue);
+    if (lookahead) {
+      error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+    }
+
+    var hue = matchNumber();
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: hsl(h, s%, l%) or hsla(h, s%, l%, a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
       scan(tokens.comma);
@@ -353,32 +448,26 @@ GradientParser.parse = (function() {
       if (!sat || !light) {
         error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsl',
-        value: [hue, sat, light]
-      };
-    });
-  }
-
-  function matchHSLAColor() {
-    return matchCall(tokens.hslaColor, function() {
-      var hue = matchNumber();
-      scan(tokens.comma);
+      if (scan(tokens.comma)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    } else {
+      // Modern space-separated syntax: hsl(h s% l%) or hsl(h s% l% / a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
-      scan(tokens.comma);
       captures = scan(tokens.percentageValue);
       var light = captures ? captures[1] : null;
-      scan(tokens.comma);
-      var alpha = matchNumber();
       if (!sat || !light) {
-        error('Expected percentage value for saturation and lightness in HSLA');
+        error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsla',
-        value: [hue, sat, light, alpha]
-      };
-    });
+      if (scan(tokens.slash)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    }
   }
 
   function matchPercentage() {
@@ -441,7 +530,14 @@ GradientParser.parse = (function() {
 
   function matchLength() {
     return match('px', tokens.pixelValue, 1) ||
-      match('em', tokens.emValue, 1);
+      match('em', tokens.emValue, 1) ||
+      match('rem', tokens.remValue, 1) ||
+      match('vw', tokens.vwValue, 1) ||
+      match('vh', tokens.vhValue, 1) ||
+      match('vmin', tokens.vminValue, 1) ||
+      match('vmax', tokens.vmaxValue, 1) ||
+      match('ch', tokens.chValue, 1) ||
+      match('ex', tokens.exValue, 1);
   }
 
   function match(type, pattern, captureIndex) {
@@ -472,7 +568,7 @@ GradientParser.parse = (function() {
   }
 
   function consume(size) {
-    input = input.substr(size);
+    input = input.substring(size);
   }
 
   return function(code) {
@@ -486,7 +582,7 @@ GradientParser.parse = (function() {
 })();
 
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -508,6 +604,14 @@ GradientParser.stringify = (function() {
     },
 
     'visit_repeating-radial-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_conic-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-conic-gradient': function(node) {
       return visitor.visit_gradient(node);
     },
 
@@ -541,7 +645,11 @@ GradientParser.stringify = (function() {
           at = visitor.visit(node.at);
 
       if (at) {
-        result += at;
+        if (node.hasAtKeyword) {
+          result += 'at ' + at;
+        } else {
+          result += at;
+        }
       }
       return result;
     },
@@ -575,6 +683,34 @@ GradientParser.stringify = (function() {
 
     'visit_px': function(node) {
       return node.value + 'px';
+    },
+
+    'visit_rem': function(node) {
+      return node.value + 'rem';
+    },
+
+    'visit_vw': function(node) {
+      return node.value + 'vw';
+    },
+
+    'visit_vh': function(node) {
+      return node.value + 'vh';
+    },
+
+    'visit_vmin': function(node) {
+      return node.value + 'vmin';
+    },
+
+    'visit_vmax': function(node) {
+      return node.value + 'vmax';
+    },
+
+    'visit_ch': function(node) {
+      return node.value + 'ch';
+    },
+
+    'visit_ex': function(node) {
+      return node.value + 'ex';
     },
 
     'visit_calc': function(node) {
@@ -616,15 +752,33 @@ GradientParser.stringify = (function() {
       if (length) {
         result += ' ' + length;
       }
+      var length2 = visitor.visit(node.length2);
+      if (length2) {
+        result += ' ' + length2;
+      }
       return result;
     },
 
     'visit_angular': function(node) {
-      return node.value + 'deg';
+      return node.value + (node.unit || 'deg');
     },
 
     'visit_directional': function(node) {
       return 'to ' + node.value;
+    },
+
+    'visit_conic': function(node) {
+      var result = '';
+      if (node.angle) {
+        result += 'from ' + visitor.visit(node.angle);
+      }
+      if (node.at) {
+        if (result) {
+          result += ' ';
+        }
+        result += 'at ' + visitor.visit(node.at);
+      }
+      return result;
     },
 
     'visit_array': function(elements) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,213 @@
+export type GradientType =
+  | 'linear-gradient'
+  | 'repeating-linear-gradient'
+  | 'radial-gradient'
+  | 'repeating-radial-gradient'
+  | 'conic-gradient'
+  | 'repeating-conic-gradient';
+
+export type AngleUnit = 'deg' | 'rad' | 'grad' | 'turn';
+
+export type LengthUnit = 'px' | 'em' | 'rem' | 'vw' | 'vh' | 'vmin' | 'vmax' | 'ch' | 'ex';
+
+export interface DirectionalNode {
+  type: 'directional';
+  value: string;
+}
+
+export interface AngularNode {
+  type: 'angular';
+  value: string;
+  unit: AngleUnit;
+}
+
+export interface ConicOrientationNode {
+  type: 'conic';
+  angle?: AngularNode;
+  at?: PositionNode;
+}
+
+export interface ShapeNode {
+  type: 'shape';
+  value: 'circle' | 'ellipse';
+  style?: LengthNode | ExtentKeywordNode | PositionNode;
+  at?: PositionNode;
+}
+
+export interface DefaultRadialNode {
+  type: 'default-radial';
+  at: PositionNode;
+  hasAtKeyword?: boolean;
+}
+
+export interface ExtentKeywordNode {
+  type: 'extent-keyword';
+  value: 'closest-side' | 'closest-corner' | 'farthest-side' | 'farthest-corner' | 'contain' | 'cover';
+  at?: PositionNode;
+}
+
+export interface PositionNode {
+  type: 'position';
+  value: {
+    x?: LengthNode | PositionKeywordNode;
+    y?: LengthNode | PositionKeywordNode;
+  };
+}
+
+export interface PositionKeywordNode {
+  type: 'position-keyword';
+  value: 'center' | 'left' | 'right' | 'top' | 'bottom';
+}
+
+export interface PercentageNode {
+  type: '%';
+  value: string;
+}
+
+export interface PxNode {
+  type: 'px';
+  value: string;
+}
+
+export interface EmNode {
+  type: 'em';
+  value: string;
+}
+
+export interface RemNode {
+  type: 'rem';
+  value: string;
+}
+
+export interface VwNode {
+  type: 'vw';
+  value: string;
+}
+
+export interface VhNode {
+  type: 'vh';
+  value: string;
+}
+
+export interface VminNode {
+  type: 'vmin';
+  value: string;
+}
+
+export interface VmaxNode {
+  type: 'vmax';
+  value: string;
+}
+
+export interface ChNode {
+  type: 'ch';
+  value: string;
+}
+
+export interface ExNode {
+  type: 'ex';
+  value: string;
+}
+
+export interface CalcNode {
+  type: 'calc';
+  value: string;
+}
+
+export type LengthNode =
+  | PercentageNode
+  | PxNode
+  | EmNode
+  | RemNode
+  | VwNode
+  | VhNode
+  | VminNode
+  | VmaxNode
+  | ChNode
+  | ExNode
+  | CalcNode
+  | PositionKeywordNode;
+
+export interface LiteralColorStop {
+  type: 'literal';
+  value: string;
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface HexColorStop {
+  type: 'hex';
+  value: string;
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface RGBColorStop {
+  type: 'rgb';
+  value: string[];
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface RGBAColorStop {
+  type: 'rgba';
+  value: string[];
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface HSLColorStop {
+  type: 'hsl';
+  value: string[];
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface HSLAColorStop {
+  type: 'hsla';
+  value: string[];
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export interface VarColorStop {
+  type: 'var';
+  value: string;
+  length?: LengthNode;
+  length2?: LengthNode;
+}
+
+export type ColorStop =
+  | LiteralColorStop
+  | HexColorStop
+  | RGBColorStop
+  | RGBAColorStop
+  | HSLColorStop
+  | HSLAColorStop
+  | VarColorStop;
+
+export type LinearOrientation = DirectionalNode | AngularNode;
+export type RadialOrientation = ShapeNode | DefaultRadialNode | ExtentKeywordNode;
+
+export interface LinearGradientNode {
+  type: 'linear-gradient' | 'repeating-linear-gradient';
+  orientation?: LinearOrientation;
+  colorStops: ColorStop[];
+}
+
+export interface RadialGradientNode {
+  type: 'radial-gradient' | 'repeating-radial-gradient';
+  orientation?: RadialOrientation[];
+  colorStops: ColorStop[];
+}
+
+export interface ConicGradientNode {
+  type: 'conic-gradient' | 'repeating-conic-gradient';
+  orientation?: ConicOrientationNode;
+  colorStops: ColorStop[];
+}
+
+export type GradientNode = LinearGradientNode | RadialGradientNode | ConicGradientNode;
+
+export function parse(gradientString: string): GradientNode[];
+export function stringify(ast: GradientNode[] | GradientNode | null): string;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -11,18 +11,30 @@ GradientParser.parse = (function() {
     repeatingLinearGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-linear\-gradient)/i,
     radialGradient: /^(\-(webkit|o|ms|moz)\-)?(radial\-gradient)/i,
     repeatingRadialGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-radial\-gradient)/i,
+    conicGradient: /^(\-(webkit|o|ms|moz)\-)?(conic\-gradient)/i,
+    repeatingConicGradient: /^(\-(webkit|o|ms|moz)\-)?(repeating\-conic\-gradient)/i,
     sideOrCorner: /^to (left (top|bottom)|right (top|bottom)|top (left|right)|bottom (left|right)|left|right|top|bottom)/i,
     extentKeywords: /^(closest\-side|closest\-corner|farthest\-side|farthest\-corner|contain|cover)/,
     positionKeywords: /^(left|center|right|top|bottom)/i,
     pixelValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))px/,
     percentageValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))\%/,
     emValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))em/,
+    remValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rem/,
+    vwValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vw/,
+    vhValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vh/,
+    vminValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmin/,
+    vmaxValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))vmax/,
+    chValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ch/,
+    exValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))ex/,
     angleValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))deg/,
     radianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))rad/,
+    gradianValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))grad/,
+    turnValue: /^(-?(([0-9]*\.[0-9]+)|([0-9]+\.?)))turn/,
     startCall: /^\(/,
     endCall: /^\)/,
     comma: /^,/,
-    hexColor: /^\#([0-9a-fA-F]+)/,
+    slash: /^\//,
+    hexColor: /^\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/,
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
     rgbaColor: /^rgba/i,
@@ -75,7 +87,17 @@ GradientParser.parse = (function() {
           matchGradient(
             'repeating-radial-gradient',
             tokens.repeatingRadialGradient,
-            matchListRadialOrientations);
+            matchListRadialOrientations) ||
+
+          matchGradient(
+            'conic-gradient',
+            tokens.conicGradient,
+            matchConicOrientation) ||
+
+          matchGradient(
+            'repeating-conic-gradient',
+            tokens.repeatingConicGradient,
+            matchConicOrientation);
   }
 
   function matchGradient(gradientType, pattern, orientationMatcher) {
@@ -135,13 +157,49 @@ GradientParser.parse = (function() {
     return matchAngle();
   }
 
+  function matchConicOrientation() {
+    var angle = matchFrom();
+    var atPosition = matchAtPosition();
+
+    if (angle || atPosition) {
+      return {
+        type: 'conic',
+        angle: angle || undefined,
+        at: atPosition || undefined
+      };
+    }
+  }
+
+  function matchFrom() {
+    if (match('from', /^from/, 0)) {
+      var angle = matchAngle();
+      if (!angle) {
+        error('Missing angle after "from" in conic-gradient');
+      }
+      return angle;
+    }
+  }
+
   function matchSideOrCorner() {
     return match('directional', tokens.sideOrCorner, 1);
   }
 
   function matchAngle() {
-    return match('angular', tokens.angleValue, 1) ||
-      match('angular', tokens.radianValue, 1);
+    return matchAngularWithUnit('deg', tokens.angleValue) ||
+      matchAngularWithUnit('rad', tokens.radianValue) ||
+      matchAngularWithUnit('grad', tokens.gradianValue) ||
+      matchAngularWithUnit('turn', tokens.turnValue);
+  }
+
+  function matchAngularWithUnit(unit, pattern) {
+    var captures = scan(pattern);
+    if (captures) {
+      return {
+        type: 'angular',
+        value: captures[1],
+        unit: unit
+      };
+    }
   }
 
   function matchListRadialOrientations() {
@@ -187,7 +245,8 @@ GradientParser.parse = (function() {
         if (atPosition) {
           radialType = {
             type: 'default-radial',
-            at: atPosition
+            at: atPosition,
+            hasAtKeyword: true
           };
         } else {
           var defaultPosition = matchPositioning();
@@ -285,6 +344,9 @@ GradientParser.parse = (function() {
     }
 
     color.length = matchDistance();
+    if (color.length) {
+      color.length2 = matchDistance();
+    }
     return color;
   }
 
@@ -308,20 +370,41 @@ GradientParser.parse = (function() {
 
   function matchRGBColor() {
     return matchCall(tokens.rgbColor, function() {
-      return  {
-        type: 'rgb',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgb');
     });
   }
 
   function matchRGBAColor() {
     return matchCall(tokens.rgbaColor, function() {
-      return  {
-        type: 'rgba',
-        value: matchListing(matchNumber)
-      };
+      return matchRGBValues('rgba');
     });
+  }
+
+  function matchRGBValues(baseType) {
+    var r = matchNumber();
+    var lookaheadCache = input;
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: rgb(r, g, b) or rgba(r, g, b, a)
+      var g = matchNumber();
+      scan(tokens.comma);
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.comma)) {
+        values.push(matchNumber());
+        return { type: baseType === 'rgba' ? 'rgba' : 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    } else {
+      // Modern space-separated syntax: rgb(r g b) or rgb(r g b / a)
+      var g = matchNumber();
+      var b = matchNumber();
+      var values = [r, g, b];
+      if (scan(tokens.slash)) {
+        values.push(matchNumber());
+        return { type: 'rgba', value: values };
+      }
+      return { type: baseType, value: values };
+    }
   }
 
   function matchVarColor() {
@@ -335,14 +418,26 @@ GradientParser.parse = (function() {
 
   function matchHSLColor() {
     return matchCall(tokens.hslColor, function() {
-      // Check for percentage before trying to parse the hue
-      var lookahead = scan(tokens.percentageValue);
-      if (lookahead) {
-        error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
-      }
-      
-      var hue = matchNumber();
-      scan(tokens.comma);
+      return matchHSLValues('hsl');
+    });
+  }
+
+  function matchHSLAColor() {
+    return matchCall(tokens.hslaColor, function() {
+      return matchHSLValues('hsla');
+    });
+  }
+
+  function matchHSLValues(baseType) {
+    // Check for percentage before trying to parse the hue
+    var lookahead = scan(tokens.percentageValue);
+    if (lookahead) {
+      error('HSL hue value must be a number in degrees (0-360) or normalized (-360 to 360), not a percentage');
+    }
+
+    var hue = matchNumber();
+    if (scan(tokens.comma)) {
+      // Legacy comma-separated syntax: hsl(h, s%, l%) or hsla(h, s%, l%, a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
       scan(tokens.comma);
@@ -351,32 +446,26 @@ GradientParser.parse = (function() {
       if (!sat || !light) {
         error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsl',
-        value: [hue, sat, light]
-      };
-    });
-  }
-
-  function matchHSLAColor() {
-    return matchCall(tokens.hslaColor, function() {
-      var hue = matchNumber();
-      scan(tokens.comma);
+      if (scan(tokens.comma)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    } else {
+      // Modern space-separated syntax: hsl(h s% l%) or hsl(h s% l% / a)
       var captures = scan(tokens.percentageValue);
       var sat = captures ? captures[1] : null;
-      scan(tokens.comma);
       captures = scan(tokens.percentageValue);
       var light = captures ? captures[1] : null;
-      scan(tokens.comma);
-      var alpha = matchNumber();
       if (!sat || !light) {
-        error('Expected percentage value for saturation and lightness in HSLA');
+        error('Expected percentage value for saturation and lightness in HSL');
       }
-      return {
-        type: 'hsla',
-        value: [hue, sat, light, alpha]
-      };
-    });
+      if (scan(tokens.slash)) {
+        var alpha = matchNumber();
+        return { type: 'hsla', value: [hue, sat, light, alpha] };
+      }
+      return { type: baseType, value: [hue, sat, light] };
+    }
   }
 
   function matchPercentage() {
@@ -439,7 +528,14 @@ GradientParser.parse = (function() {
 
   function matchLength() {
     return match('px', tokens.pixelValue, 1) ||
-      match('em', tokens.emValue, 1);
+      match('em', tokens.emValue, 1) ||
+      match('rem', tokens.remValue, 1) ||
+      match('vw', tokens.vwValue, 1) ||
+      match('vh', tokens.vhValue, 1) ||
+      match('vmin', tokens.vminValue, 1) ||
+      match('vmax', tokens.vmaxValue, 1) ||
+      match('ch', tokens.chValue, 1) ||
+      match('ex', tokens.exValue, 1);
   }
 
   function match(type, pattern, captureIndex) {
@@ -470,7 +566,7 @@ GradientParser.parse = (function() {
   }
 
   function consume(size) {
-    input = input.substr(size);
+    input = input.substring(size);
   }
 
   return function(code) {

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 Rafael Caricio. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Use of this source code is governed by an MIT license that can be
 // found in the LICENSE file.
 
 var GradientParser = (GradientParser || {});
@@ -21,6 +21,14 @@ GradientParser.stringify = (function() {
     },
 
     'visit_repeating-radial-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_conic-gradient': function(node) {
+      return visitor.visit_gradient(node);
+    },
+
+    'visit_repeating-conic-gradient': function(node) {
       return visitor.visit_gradient(node);
     },
 
@@ -54,7 +62,11 @@ GradientParser.stringify = (function() {
           at = visitor.visit(node.at);
 
       if (at) {
-        result += at;
+        if (node.hasAtKeyword) {
+          result += 'at ' + at;
+        } else {
+          result += at;
+        }
       }
       return result;
     },
@@ -88,6 +100,34 @@ GradientParser.stringify = (function() {
 
     'visit_px': function(node) {
       return node.value + 'px';
+    },
+
+    'visit_rem': function(node) {
+      return node.value + 'rem';
+    },
+
+    'visit_vw': function(node) {
+      return node.value + 'vw';
+    },
+
+    'visit_vh': function(node) {
+      return node.value + 'vh';
+    },
+
+    'visit_vmin': function(node) {
+      return node.value + 'vmin';
+    },
+
+    'visit_vmax': function(node) {
+      return node.value + 'vmax';
+    },
+
+    'visit_ch': function(node) {
+      return node.value + 'ch';
+    },
+
+    'visit_ex': function(node) {
+      return node.value + 'ex';
     },
 
     'visit_calc': function(node) {
@@ -129,15 +169,33 @@ GradientParser.stringify = (function() {
       if (length) {
         result += ' ' + length;
       }
+      var length2 = visitor.visit(node.length2);
+      if (length2) {
+        result += ' ' + length2;
+      }
       return result;
     },
 
     'visit_angular': function(node) {
-      return node.value + 'deg';
+      return node.value + (node.unit || 'deg');
     },
 
     'visit_directional': function(node) {
       return 'to ' + node.value;
+    },
+
+    'visit_conic': function(node) {
+      var result = '';
+      if (node.angle) {
+        result += 'from ' + visitor.visit(node.angle);
+      }
+      if (node.at) {
+        if (result) {
+          result += ' ';
+        }
+        result += 'at ' + visitor.visit(node.at);
+      }
+      return result;
     },
 
     'visit_array': function(elements) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gradient-parser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gradient-parser",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "esbuild": "^0.25.0",
         "expect.js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,18 @@
     "url": "git://github.com/rafaelcaricio/gradient-parser.git"
   },
   "main": "build/node.js",
+  "module": "build/esm.mjs",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/esm.mjs",
+      "require": "./build/node.js",
+      "types": "./index.d.ts"
+    }
+  },
   "scripts": {
     "test": "mocha spec/**/*.js",
+    "pretest": "npm run build",
     "build": "node build.js",
     "build:node": "node build.js --node",
     "build:web": "node build.js --web",
@@ -36,7 +46,11 @@
   "keywords": [
     "library",
     "css3",
-    "parser"
+    "parser",
+    "gradient",
+    "conic-gradient",
+    "linear-gradient",
+    "radial-gradient"
   ],
   "devDependencies": {
     "expect.js": "^0.3.1",
@@ -44,6 +58,6 @@
     "mocha": "^10.3.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=18.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:node": "node build.js --node",
     "build:web": "node build.js --web",
     "build:minify": "node build.js --minify",
-    "start": "python -m SimpleHTTPServer 3000",
+    "start": "python3 -m http.server 3000",
     "prepublish": "npm run build"
   },
   "keywords": [

--- a/spec/parser.spec.js
+++ b/spec/parser.spec.js
@@ -607,4 +607,189 @@ describe('lib/parser.js', function () {
     });
   });
 
+  describe('parse conic gradients', function() {
+    it('should parse simple conic-gradient', function() {
+      var ast = gradients.parse('conic-gradient(red, blue)');
+      expect(ast[0].type).to.equal('conic-gradient');
+      expect(ast[0].colorStops).to.have.length(2);
+      expect(ast[0].colorStops[0].value).to.equal('red');
+      expect(ast[0].colorStops[1].value).to.equal('blue');
+    });
+
+    it('should parse conic-gradient with from angle', function() {
+      var ast = gradients.parse('conic-gradient(from 45deg, red, blue)');
+      expect(ast[0].type).to.equal('conic-gradient');
+      expect(ast[0].orientation.type).to.equal('conic');
+      expect(ast[0].orientation.angle.type).to.equal('angular');
+      expect(ast[0].orientation.angle.value).to.equal('45');
+      expect(ast[0].orientation.angle.unit).to.equal('deg');
+    });
+
+    it('should parse conic-gradient with at position', function() {
+      var ast = gradients.parse('conic-gradient(at 50% 50%, red, blue)');
+      expect(ast[0].type).to.equal('conic-gradient');
+      expect(ast[0].orientation.type).to.equal('conic');
+      expect(ast[0].orientation.at.type).to.equal('position');
+      expect(ast[0].orientation.at.value.x.value).to.equal('50');
+      expect(ast[0].orientation.at.value.y.value).to.equal('50');
+    });
+
+    it('should parse conic-gradient with from angle and at position', function() {
+      var ast = gradients.parse('conic-gradient(from 90deg at 25% 75%, red, yellow, blue)');
+      expect(ast[0].type).to.equal('conic-gradient');
+      expect(ast[0].orientation.angle.value).to.equal('90');
+      expect(ast[0].orientation.angle.unit).to.equal('deg');
+      expect(ast[0].orientation.at.type).to.equal('position');
+      expect(ast[0].orientation.at.value.x.value).to.equal('25');
+      expect(ast[0].orientation.at.value.y.value).to.equal('75');
+      expect(ast[0].colorStops).to.have.length(3);
+    });
+
+    it('should parse repeating-conic-gradient', function() {
+      var ast = gradients.parse('repeating-conic-gradient(from 0deg, red 0%, blue 25%)');
+      expect(ast[0].type).to.equal('repeating-conic-gradient');
+      expect(ast[0].orientation.angle.value).to.equal('0');
+      expect(ast[0].colorStops).to.have.length(2);
+    });
+  });
+
+  describe('parse additional angle units', function() {
+    it('should parse grad angle unit', function() {
+      var ast = gradients.parse('linear-gradient(100grad, red, blue)');
+      expect(ast[0].orientation.type).to.equal('angular');
+      expect(ast[0].orientation.value).to.equal('100');
+      expect(ast[0].orientation.unit).to.equal('grad');
+    });
+
+    it('should parse turn angle unit', function() {
+      var ast = gradients.parse('linear-gradient(0.25turn, red, blue)');
+      expect(ast[0].orientation.type).to.equal('angular');
+      expect(ast[0].orientation.value).to.equal('0.25');
+      expect(ast[0].orientation.unit).to.equal('turn');
+    });
+
+    it('should preserve deg unit in AST', function() {
+      var ast = gradients.parse('linear-gradient(45deg, red, blue)');
+      expect(ast[0].orientation.unit).to.equal('deg');
+    });
+
+    it('should preserve rad unit in AST', function() {
+      var ast = gradients.parse('linear-gradient(1rad, red, blue)');
+      expect(ast[0].orientation.unit).to.equal('rad');
+    });
+  });
+
+  describe('parse additional CSS length units', function() {
+    [
+      {unit: 'rem', input: '2rem'},
+      {unit: 'vw', input: '50vw'},
+      {unit: 'vh', input: '100vh'},
+      {unit: 'vmin', input: '10vmin'},
+      {unit: 'vmax', input: '90vmax'},
+      {unit: 'ch', input: '5ch'},
+      {unit: 'ex', input: '3ex'}
+    ].forEach(function(tc) {
+      it('should parse ' + tc.unit + ' unit in color stop', function() {
+        var ast = gradients.parse('linear-gradient(red ' + tc.input + ', blue)');
+        expect(ast[0].colorStops[0].length.type).to.equal(tc.unit);
+      });
+    });
+  });
+
+  describe('parse CSS Color Level 4 space-separated syntax', function() {
+    it('should parse rgb with space-separated values', function() {
+      var ast = gradients.parse('linear-gradient(rgb(255 0 128), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].value).to.eql(['255', '0', '128']);
+    });
+
+    it('should parse rgb with slash alpha', function() {
+      var ast = gradients.parse('linear-gradient(rgb(255 0 128 / 0.5), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('rgba');
+      expect(ast[0].colorStops[0].value).to.eql(['255', '0', '128', '0.5']);
+    });
+
+    it('should parse hsl with space-separated values', function() {
+      var ast = gradients.parse('linear-gradient(hsl(120 60% 70%), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('hsl');
+      expect(ast[0].colorStops[0].value).to.eql(['120', '60', '70']);
+    });
+
+    it('should parse hsl with slash alpha', function() {
+      var ast = gradients.parse('linear-gradient(hsl(120 60% 70% / 0.5), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('hsla');
+      expect(ast[0].colorStops[0].value).to.eql(['120', '60', '70', '0.5']);
+    });
+
+    it('should still parse legacy comma-separated rgb', function() {
+      var ast = gradients.parse('linear-gradient(rgb(255, 0, 128), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('rgb');
+      expect(ast[0].colorStops[0].value).to.eql(['255', '0', '128']);
+    });
+
+    it('should still parse legacy comma-separated hsl', function() {
+      var ast = gradients.parse('linear-gradient(hsl(120, 60%, 70%), blue)');
+      expect(ast[0].colorStops[0].type).to.equal('hsl');
+      expect(ast[0].colorStops[0].value).to.eql(['120', '60', '70']);
+    });
+  });
+
+  describe('parse dual color stop positions', function() {
+    it('should parse color stop with two positions', function() {
+      var ast = gradients.parse('linear-gradient(red 10% 30%, blue)');
+      expect(ast[0].colorStops[0].length.type).to.equal('%');
+      expect(ast[0].colorStops[0].length.value).to.equal('10');
+      expect(ast[0].colorStops[0].length2.type).to.equal('%');
+      expect(ast[0].colorStops[0].length2.value).to.equal('30');
+    });
+
+    it('should parse dual positions with px', function() {
+      var ast = gradients.parse('linear-gradient(red 10px 50px, blue)');
+      expect(ast[0].colorStops[0].length.type).to.equal('px');
+      expect(ast[0].colorStops[0].length.value).to.equal('10');
+      expect(ast[0].colorStops[0].length2.type).to.equal('px');
+      expect(ast[0].colorStops[0].length2.value).to.equal('50');
+    });
+
+    it('should not set length2 for single position', function() {
+      var ast = gradients.parse('linear-gradient(red 50%, blue)');
+      expect(ast[0].colorStops[0].length.type).to.equal('%');
+      expect(ast[0].colorStops[0].length2).to.be(undefined);
+    });
+  });
+
+  describe('hex color validation', function() {
+    it('should parse 3-digit hex', function() {
+      var ast = gradients.parse('linear-gradient(#fff, blue)');
+      expect(ast[0].colorStops[0].value).to.equal('fff');
+    });
+
+    it('should parse 4-digit hex (with alpha)', function() {
+      var ast = gradients.parse('linear-gradient(#fffa, blue)');
+      expect(ast[0].colorStops[0].value).to.equal('fffa');
+    });
+
+    it('should parse 6-digit hex', function() {
+      var ast = gradients.parse('linear-gradient(#ff00ff, blue)');
+      expect(ast[0].colorStops[0].value).to.equal('ff00ff');
+    });
+
+    it('should parse 8-digit hex (with alpha)', function() {
+      var ast = gradients.parse('linear-gradient(#ff00ff80, blue)');
+      expect(ast[0].colorStops[0].value).to.equal('ff00ff80');
+    });
+
+    it('should reject invalid hex lengths', function() {
+      expect(function() {
+        gradients.parse('linear-gradient(#ff, blue)');
+      }).to.throwException();
+      expect(function() {
+        gradients.parse('linear-gradient(#fffff, blue)');
+      }).to.throwException();
+      expect(function() {
+        gradients.parse('linear-gradient(#fffffff, blue)');
+      }).to.throwException();
+    });
+  });
+
 });

--- a/spec/stringify.spec.js
+++ b/spec/stringify.spec.js
@@ -113,6 +113,91 @@ describe('lib/stringify.js', function () {
       });
     });
 
+    describe('angle unit preservation', function() {
+      it('should round-trip rad values', function() {
+        var gradientDef = 'linear-gradient(1rad, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip grad values', function() {
+        var gradientDef = 'linear-gradient(100grad, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip turn values', function() {
+        var gradientDef = 'linear-gradient(0.25turn, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip deg values', function() {
+        var gradientDef = 'linear-gradient(45deg, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+    });
+
+    describe('conic-gradient serialization', function() {
+      it('should round-trip simple conic-gradient', function() {
+        var gradientDef = 'conic-gradient(red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip conic-gradient with from angle', function() {
+        var gradientDef = 'conic-gradient(from 45deg, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip conic-gradient with at position', function() {
+        var gradientDef = 'conic-gradient(at 50% 50%, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip conic-gradient with from and at', function() {
+        var gradientDef = 'conic-gradient(from 90deg at 25% 75%, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip repeating-conic-gradient', function() {
+        var gradientDef = 'repeating-conic-gradient(from 0deg, red 0%, blue 25%)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+    });
+
+    describe('additional length units', function() {
+      [
+        'rem',
+        'vw',
+        'vh',
+        'vmin',
+        'vmax',
+        'ch',
+        'ex'
+      ].forEach(function(unit) {
+        it('should round-trip ' + unit + ' unit', function() {
+          var gradientDef = 'linear-gradient(blue 10' + unit + ', transparent)';
+          expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+        });
+      });
+    });
+
+    describe('radial with explicit at keyword', function() {
+      it('should round-trip radial-gradient with at position', function() {
+        var gradientDef = 'radial-gradient(at 57% 50%, red, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+    });
+
+    describe('dual color stop positions', function() {
+      it('should round-trip dual percentage positions', function() {
+        var gradientDef = 'linear-gradient(red 10% 30%, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+
+      it('should round-trip dual px positions', function() {
+        var gradientDef = 'linear-gradient(red 10px 50px, blue)';
+        expect(gradients.stringify(gradients.parse(gradientDef))).to.equal(gradientDef);
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
High-priority bug fixes:
- Fix stringify visit_angular always emitting 'deg' (now preserves rad/grad/turn)
- Fix stringify visit_default-radial missing 'at' keyword for explicit at-positions
- Replace deprecated String.substr() with substring()
- Validate hex color to only accept 3, 4, 6, or 8 digit lengths
- Fix license headers (BSD -> MIT) to match package.json/README
- Fix start script to use Python 3 (python -m http.server)

New CSS feature support:
- Add conic-gradient() and repeating-conic-gradient() parsing and stringification
- Add grad and turn angle units (alongside existing deg and rad)
- Add rem, vw, vh, vmin, vmax, ch, ex length units for color stop positions
- Add CSS Color Level 4 space-separated color syntax (rgb(255 0 0 / 0.5), hsl(120 60% 70% / 0.5))
- Support dual color stop positions (e.g. red 10% 30%)

All 144 tests pass (95 existing + 49 new).

https://claude.ai/code/session_01HYURCvRuSARp2j8Qi5nP83